### PR TITLE
TUI: resolve ambiguous import accounts via Decisions pane

### DIFF
--- a/application/imports/account_discovery.py
+++ b/application/imports/account_discovery.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import datetime as dt
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from beanbeaver.application.imports.shared import select_interactive_option
 from beanbeaver.ledger_access import open_accounts
@@ -38,6 +40,32 @@ BANK_TRANSFER_RULES: list[tuple[str, list[str]]] = [
 _CC_TRANSFER_HINTS = ("MASTERCARD", "VISA", "AMEX", "CREDIT CARD")
 
 
+ResolutionKind = Literal["resolved", "ambiguous", "no_match"]
+
+
+@dataclass(frozen=True)
+class AccountResolution:
+    """Outcome of an account-discovery attempt expressed as data."""
+
+    kind: ResolutionKind
+    pattern: str | None = None
+    account: str | None = None
+    candidates: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TransactionKey:
+    """Stable identifier for a parsed transaction row used to key overrides."""
+
+    date: str
+    description: str
+    amount: str
+
+    @classmethod
+    def from_parsed(cls, date: dt.date, description: str, amount: object) -> TransactionKey:
+        return cls(date=date.isoformat(), description=description, amount=str(amount))
+
+
 def find_open_accounts(
     patterns: list[str],
     *,
@@ -53,20 +81,14 @@ def find_open_accounts(
     )
 
 
-def resolve_cc_payment_account(
+def resolve_cc_payment_account_strict(
     description: str,
     *,
     as_of: dt.date | None = None,
     ledger_path: Path | None = None,
-    cache: dict[str, str | None] | None = None,
-    txn_date: dt.date | None = None,
-    amount: str | None = None,
-) -> str | None:
-    """
-    Resolve a credit card payment description to an open liability account.
-
-    Returns None when no match is found. Prompts on ambiguity if TTY, otherwise fails.
-    """
+    cache: dict[str, AccountResolution] | None = None,
+) -> AccountResolution:
+    """Resolve a CC-payment description without prompting; ambiguity is returned as data."""
     desc_upper = description.upper()
     for pattern, account_patterns in CC_PAYMENT_RULES:
         if pattern not in desc_upper:
@@ -77,55 +99,37 @@ def resolve_cc_payment_account(
 
         matches = find_open_accounts(account_patterns, as_of=as_of, ledger_path=ledger_path)
         if not matches:
-            if cache is not None:
-                cache[pattern] = None
-            return None
-        if len(matches) == 1:
-            if cache is not None:
-                cache[pattern] = matches[0]
-            return matches[0]
-        context = []
-        if txn_date:
-            context.append(f"date={txn_date.isoformat()}")
-        if amount:
-            context.append(f"amount={amount}")
-        context_str = f" ({', '.join(context)})" if context else ""
+            resolution = AccountResolution(kind="no_match", pattern=pattern)
+        elif len(matches) == 1:
+            resolution = AccountResolution(kind="resolved", pattern=pattern, account=matches[0])
+        else:
+            resolution = AccountResolution(
+                kind="ambiguous",
+                pattern=pattern,
+                candidates=tuple(matches),
+            )
 
-        selected = select_interactive_option(
-            matches,
-            heading=f"Multiple credit card accounts match payment pattern '{pattern}'{context_str}:",
-            prompt="Select account (number): ",
-            non_tty_error=(
-                f"Multiple credit card accounts match payment pattern '{pattern}'{context_str}. "
-                "Run interactively to choose"
-            ),
-            invalid_choice_error="Invalid account selection",
-        )
         if cache is not None:
-            cache[pattern] = selected
-        return selected
+            cache[pattern] = resolution
+        return resolution
 
-    return None
+    return AccountResolution(kind="no_match")
 
 
-def resolve_bank_transfer_account(
+def resolve_bank_transfer_account_strict(
     description: str,
     *,
     as_of: dt.date | None = None,
     ledger_path: Path | None = None,
     source_account: str | None = None,
-    cache: dict[str, str | None] | None = None,
-) -> str | None:
-    """
-    Resolve an internal bank transfer description to an open bank account.
-
-    Returns None when no reliable target match is found.
-    """
+    cache: dict[str, AccountResolution] | None = None,
+) -> AccountResolution:
+    """Resolve a bank-transfer description without prompting; ambiguity is returned as data."""
     desc_upper = description.upper()
     if "TRANSFER TO" not in desc_upper and "TRANSFER FROM" not in desc_upper:
-        return None
+        return AccountResolution(kind="no_match")
     if any(token in desc_upper for token in _CC_TRANSFER_HINTS):
-        return None
+        return AccountResolution(kind="no_match")
 
     if "TRANSFER TO" in desc_upper:
         target_segment = desc_upper.split("TRANSFER TO", 1)[1]
@@ -145,10 +149,15 @@ def resolve_bank_transfer_account(
             seen_labels.add(label)
             candidate_labels.append(label)
 
+    last_seen: AccountResolution = AccountResolution(kind="no_match")
     for label in candidate_labels:
         cache_key = f"bank-transfer:{label}:{source_account or ''}"
         if cache is not None and cache_key in cache:
-            return cache[cache_key]
+            cached = cache[cache_key]
+            if cached.kind != "no_match":
+                return cached
+            last_seen = cached
+            continue
 
         patterns = next((rule_patterns for rule_label, rule_patterns in BANK_TRANSFER_RULES if rule_label == label), [])
         matches = find_open_accounts(patterns, as_of=as_of, ledger_path=ledger_path)
@@ -156,13 +165,15 @@ def resolve_bank_transfer_account(
             matches = [account for account in matches if account != source_account]
 
         if not matches:
+            last_seen = AccountResolution(kind="no_match", pattern=label)
             if cache is not None:
-                cache[cache_key] = None
+                cache[cache_key] = last_seen
             continue
         if len(matches) == 1:
+            resolution = AccountResolution(kind="resolved", pattern=label, account=matches[0])
             if cache is not None:
-                cache[cache_key] = matches[0]
-            return matches[0]
+                cache[cache_key] = resolution
+            return resolution
 
         normalized_label = label.replace(" ", "").upper()
         narrowed = [
@@ -171,12 +182,106 @@ def resolve_bank_transfer_account(
             if normalized_label in account.replace("-", "").replace("_", "").replace(" ", "").upper()
         ]
         if len(narrowed) == 1:
+            resolution = AccountResolution(kind="resolved", pattern=label, account=narrowed[0])
             if cache is not None:
-                cache[cache_key] = narrowed[0]
-            return narrowed[0]
+                cache[cache_key] = resolution
+            return resolution
 
+        resolution = AccountResolution(
+            kind="ambiguous",
+            pattern=label,
+            candidates=tuple(matches),
+        )
         if cache is not None:
-            cache[cache_key] = None
-        return None
+            cache[cache_key] = resolution
+        return resolution
 
+    return last_seen
+
+
+def resolve_cc_payment_account(
+    description: str,
+    *,
+    as_of: dt.date | None = None,
+    ledger_path: Path | None = None,
+    cache: dict[str, str | None] | None = None,
+    txn_date: dt.date | None = None,
+    amount: str | None = None,
+) -> str | None:
+    """
+    Resolve a credit card payment description to an open liability account.
+
+    Returns None when no match is found. Prompts on ambiguity if TTY, otherwise raises RuntimeError.
+    Kept as the CLI-facing wrapper around resolve_cc_payment_account_strict.
+    """
+    if cache is not None and description.upper() in cache:
+        # Legacy cache contract: keyed by pattern, but callers don't depend on that distinction
+        # because each pattern is unique within a description scan. We keep a passthrough wrapper.
+        pass
+
+    resolution = resolve_cc_payment_account_strict(
+        description,
+        as_of=as_of,
+        ledger_path=ledger_path,
+    )
+    if resolution.kind == "no_match":
+        if cache is not None and resolution.pattern is not None:
+            cache[resolution.pattern] = None
+        return None
+    if resolution.kind == "resolved":
+        if cache is not None and resolution.pattern is not None:
+            cache[resolution.pattern] = resolution.account
+        return resolution.account
+
+    assert resolution.kind == "ambiguous"
+    assert resolution.pattern is not None
+    if cache is not None and resolution.pattern in cache:
+        return cache[resolution.pattern]
+
+    context = []
+    if txn_date:
+        context.append(f"date={txn_date.isoformat()}")
+    if amount:
+        context.append(f"amount={amount}")
+    context_str = f" ({', '.join(context)})" if context else ""
+
+    selected = select_interactive_option(
+        list(resolution.candidates),
+        heading=f"Multiple credit card accounts match payment pattern '{resolution.pattern}'{context_str}:",
+        prompt="Select account (number): ",
+        non_tty_error=(
+            f"Multiple credit card accounts match payment pattern '{resolution.pattern}'{context_str}. "
+            "Run interactively to choose"
+        ),
+        invalid_choice_error="Invalid account selection",
+    )
+    if cache is not None:
+        cache[resolution.pattern] = selected
+    return selected
+
+
+def resolve_bank_transfer_account(
+    description: str,
+    *,
+    as_of: dt.date | None = None,
+    ledger_path: Path | None = None,
+    source_account: str | None = None,
+    cache: dict[str, str | None] | None = None,
+) -> str | None:
+    """
+    Resolve an internal bank transfer description to an open bank account.
+
+    Returns None when no reliable target match is found (preserves prior behavior:
+    ambiguity falls through to the categorizer instead of prompting).
+    """
+    resolution = resolve_bank_transfer_account_strict(
+        description,
+        as_of=as_of,
+        ledger_path=ledger_path,
+        source_account=source_account,
+    )
+    if resolution.kind == "resolved":
+        if cache is not None and resolution.pattern is not None:
+            cache[f"bank-transfer:{resolution.pattern}:{source_account or ''}"] = resolution.account
+        return resolution.account
     return None

--- a/application/imports/chequing.py
+++ b/application/imports/chequing.py
@@ -13,9 +13,12 @@ from pathlib import Path
 from typing import Literal
 
 from beanbeaver.application.imports.account_discovery import (
+    AccountResolution,
+    TransactionKey,
     find_open_accounts,
-    resolve_bank_transfer_account,
+    resolve_bank_transfer_account_strict,
     resolve_cc_payment_account,
+    resolve_cc_payment_account_strict,
 )
 from beanbeaver.application.imports.csv_routing import detect_chequing_csv as detect_chequing_csv_by_rules
 from beanbeaver.application.imports.shared import (
@@ -61,12 +64,47 @@ ChequingImportStatus = Literal["ok", "aborted", "error"]
 
 
 @dataclass(frozen=True)
+class TransactionOverride:
+    """User-provided override that pins a specific transaction row to a chosen account."""
+
+    transaction: TransactionKey
+    account: str
+
+
+@dataclass(frozen=True)
 class ChequingImportRequest:
     """Inputs for chequing statement import workflow."""
 
     csv_file: str | None = None
     selected_account: str | None = None
     allow_uncommitted: bool | None = None
+    cc_payment_overrides: tuple[TransactionOverride, ...] = ()
+    bank_transfer_overrides: tuple[TransactionOverride, ...] = ()
+    interactive: bool = True
+
+
+DecisionKind = Literal["cc_payment", "bank_transfer"]
+
+
+@dataclass(frozen=True)
+class ImportDecision:
+    """One ambiguous resolution that the caller must pick before apply succeeds."""
+
+    kind: DecisionKind
+    pattern: str
+    transaction: TransactionKey
+    candidates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PreflightChequingResult:
+    """Preflight outcome: a list of decisions and any preflight-time error."""
+
+    status: Literal["ok", "error"]
+    chequing_type: str | None = None
+    account: str | None = None
+    decisions: tuple[ImportDecision, ...] = ()
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -157,6 +195,186 @@ def parse_chequing_request(argv: Sequence[str] | None = None) -> ChequingImportR
     parser.add_argument("csv_file", nargs="?", help="CSV file to import (auto-detect if omitted)")
     args = parser.parse_args(argv)
     return ChequingImportRequest(csv_file=args.csv_file)
+
+
+def _overrides_map(overrides: tuple["TransactionOverride", ...]) -> dict[TransactionKey, str]:
+    return {override.transaction: override.account for override in overrides}
+
+
+def _resolve_cc_for_row(
+    *,
+    description: str,
+    date: datetime.date,
+    amount_val: Decimal,
+    as_of: datetime.date | None,
+    interactive: bool,
+    cache: dict[str, str | None],
+    pending: list[ImportDecision],
+    txn_key: TransactionKey,
+) -> "str | None | ChequingImportResult":
+    """Resolve a CC payment account for one row, queuing decisions or prompting per mode."""
+    if interactive:
+        try:
+            return resolve_cc_payment_account(
+                description,
+                as_of=as_of,
+                cache=cache,
+                txn_date=date,
+                amount=f"{amount_val} CAD",
+            )
+        except RuntimeError as exc:
+            return ChequingImportResult(status="error", error=str(exc))
+
+    resolution = resolve_cc_payment_account_strict(description, as_of=as_of)
+    if resolution.kind == "resolved":
+        return resolution.account
+    if resolution.kind == "no_match":
+        return None
+    assert resolution.kind == "ambiguous" and resolution.pattern is not None
+    pending.append(
+        ImportDecision(
+            kind="cc_payment",
+            pattern=resolution.pattern,
+            transaction=txn_key,
+            candidates=resolution.candidates,
+        )
+    )
+    return None
+
+
+def _resolve_transfer_for_row(
+    *,
+    description: str,
+    as_of: datetime.date | None,
+    source_account: str,
+    cache: dict[str, str | None],
+    pending: list[ImportDecision],
+    txn_key: TransactionKey,
+) -> str | None:
+    """Resolve a bank-transfer account for one row, queuing decisions when ambiguous."""
+    resolution = resolve_bank_transfer_account_strict(
+        description,
+        as_of=as_of,
+        source_account=source_account,
+    )
+    if resolution.kind == "resolved":
+        if resolution.pattern is not None:
+            cache[f"bank-transfer:{resolution.pattern}:{source_account or ''}"] = resolution.account
+        return resolution.account
+    if resolution.kind == "ambiguous" and resolution.pattern is not None:
+        pending.append(
+            ImportDecision(
+                kind="bank_transfer",
+                pattern=resolution.pattern,
+                transaction=txn_key,
+                candidates=resolution.candidates,
+            )
+        )
+    # ambiguous bank transfers: do not legacy-fallback; let the caller treat as None and categorize.
+    return None
+
+
+def _read_chequing_csv_rows(csv_file: str) -> tuple[Path, str, list[tuple[datetime.date, str, Decimal, Decimal]]]:
+    """Copy CSV to TMP, detect type, parse rows. Returns (target_path, chequing_type, parsed_rows)."""
+    target_file_name = TMPDIR / "chequing.csv"
+    copy_statement_csv(
+        csv_file=csv_file,
+        target_path=target_file_name,
+        downloads_dir=DOWNLOADED_CSV_BASE_PATH,
+        allow_absolute=True,
+    )
+    chequing_type = detect_chequing_type(target_file_name)
+
+    import csv
+
+    with open(target_file_name, encoding="utf-8-sig") as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = list(reader)
+
+    if chequing_type == "eqbank":
+        parsed_rows = parse_eqbank_rows(rows)
+    else:
+        parsed_rows = parse_scotia_rows(rows)
+    return target_file_name, chequing_type, parsed_rows
+
+
+def preflight_chequing_import(
+    *,
+    csv_file: str,
+    selected_account: str | None = None,
+) -> PreflightChequingResult:
+    """Walk a chequing CSV and surface ambiguous CC-payment / bank-transfer decisions."""
+    try:
+        _, chequing_type, parsed_rows = _read_chequing_csv_rows(csv_file)
+    except FileNotFoundError:
+        return PreflightChequingResult(status="error", error=f"File not found: {csv_file}")
+    except ValueError as exc:
+        return PreflightChequingResult(status="error", error=str(exc))
+
+    as_of = latest_date(parsed_rows)
+    patterns = EQBANK_ACCOUNT_PATTERNS if chequing_type == "eqbank" else SCOTIA_ACCOUNT_PATTERNS
+    label = "EQ Bank chequing" if chequing_type == "eqbank" else "Scotia chequing"
+    try:
+        account = _select_chequing_account(
+            patterns,
+            label=label,
+            as_of=as_of,
+            selected_account=selected_account,
+        )
+    except RuntimeError as exc:
+        return PreflightChequingResult(status="error", chequing_type=chequing_type, error=str(exc))
+
+    decisions: list[ImportDecision] = []
+    cc_resolution_cache: dict[str, AccountResolution] = {}
+    seen_keys: set[tuple[str, str, str, str, str]] = set()
+    for date, description, amount_val, _balance_val in parsed_rows:
+        txn_key = TransactionKey.from_parsed(date, description, amount_val)
+        cc_resolution = resolve_cc_payment_account_strict(
+            description,
+            as_of=as_of,
+            cache=cc_resolution_cache,
+        )
+        if cc_resolution.kind == "ambiguous" and cc_resolution.pattern is not None:
+            dedup = ("cc_payment", cc_resolution.pattern, txn_key.date, txn_key.description, txn_key.amount)
+            if dedup not in seen_keys:
+                seen_keys.add(dedup)
+                decisions.append(
+                    ImportDecision(
+                        kind="cc_payment",
+                        pattern=cc_resolution.pattern,
+                        transaction=txn_key,
+                        candidates=cc_resolution.candidates,
+                    )
+                )
+            continue
+
+        if cc_resolution.kind == "resolved":
+            continue
+
+        bank_resolution = resolve_bank_transfer_account_strict(
+            description,
+            as_of=as_of,
+            source_account=account,
+        )
+        if bank_resolution.kind == "ambiguous" and bank_resolution.pattern is not None:
+            dedup = ("bank_transfer", bank_resolution.pattern, txn_key.date, txn_key.description, txn_key.amount)
+            if dedup not in seen_keys:
+                seen_keys.add(dedup)
+                decisions.append(
+                    ImportDecision(
+                        kind="bank_transfer",
+                        pattern=bank_resolution.pattern,
+                        transaction=txn_key,
+                        candidates=bank_resolution.candidates,
+                    )
+                )
+
+    return PreflightChequingResult(
+        status="ok",
+        chequing_type=chequing_type,
+        account=account,
+        decisions=tuple(decisions),
+    )
 
 
 def run_chequing_import(request: ChequingImportRequest, *, emit_console_output: bool = True) -> ChequingImportResult:
@@ -268,39 +486,65 @@ def run_chequing_import(request: ChequingImportRequest, *, emit_console_output: 
 
     # Process transactions - sorted by date
     entries: list[tuple[datetime.date, str]] = []
+    cc_overrides_map = _overrides_map(request.cc_payment_overrides)
+    bank_overrides_map = _overrides_map(request.bank_transfer_overrides)
+    pending_decisions: list[ImportDecision] = []
     cc_cache: dict[str, str | None] = {}
     transfer_cache: dict[str, str | None] = {}
     for date, description, amount_val, _balance_val in parsed_rows:
-        try:
-            cc_account = resolve_cc_payment_account(
-                description,
-                as_of=as_of,
-                cache=cc_cache,
-                txn_date=date,
-                amount=f"{amount_val} CAD",
-            )
-        except RuntimeError as exc:
-            return ChequingImportResult(status="error", error=str(exc))
-        if cc_account:
-            expense_account = cc_account
+        txn_key = TransactionKey.from_parsed(date, description, amount_val)
+        cc_override = cc_overrides_map.get(txn_key)
+        if cc_override is not None:
+            expense_account = cc_override
         else:
-            try:
-                transfer_account = resolve_bank_transfer_account(
-                    description,
-                    as_of=as_of,
-                    source_account=account,
-                    cache=transfer_cache,
-                )
-            except RuntimeError as exc:
-                return ChequingImportResult(status="error", error=str(exc))
-            if transfer_account:
-                expense_account = transfer_account
+            cc_account = _resolve_cc_for_row(
+                description=description,
+                date=date,
+                amount_val=amount_val,
+                as_of=as_of,
+                interactive=request.interactive,
+                cache=cc_cache,
+                pending=pending_decisions,
+                txn_key=txn_key,
+            )
+            if isinstance(cc_account, ChequingImportResult):
+                return cc_account
+            if cc_account is not None:
+                expense_account = cc_account
             else:
-                category = categorize_chequing_transaction(description, patterns=categorization_patterns)
-                expense_account = category if category else "Expenses:Uncategorized"
+                bank_override = bank_overrides_map.get(txn_key)
+                if bank_override is not None:
+                    expense_account = bank_override
+                else:
+                    transfer_account = _resolve_transfer_for_row(
+                        description=description,
+                        as_of=as_of,
+                        source_account=account,
+                        cache=transfer_cache,
+                        pending=pending_decisions,
+                        txn_key=txn_key,
+                    )
+                    if transfer_account is not None:
+                        expense_account = transfer_account
+                    else:
+                        category = categorize_chequing_transaction(description, patterns=categorization_patterns)
+                        expense_account = category if category else "Expenses:Uncategorized"
 
         txn_text = format_transaction(date, description, amount_val, account, expense_account)
         entries.append((date, txn_text))
+
+    if pending_decisions:
+        rendered = "; ".join(
+            f"{decision.kind} '{decision.pattern}' for {decision.transaction.date} {decision.transaction.amount}"
+            for decision in pending_decisions
+        )
+        return ChequingImportResult(
+            status="error",
+            error=(
+                f"Apply blocked: {len(pending_decisions)} ambiguous account decision(s) "
+                f"need explicit overrides — {rendered}"
+            ),
+        )
 
     for balance_date, balance_amount in filtered_balances:
         balance_text = format_balance(balance_date, account, balance_amount)

--- a/application/imports/service.py
+++ b/application/imports/service.py
@@ -59,6 +59,16 @@ class RefreshImportPageResult:
 
 
 @dataclass(frozen=True)
+class TransactionOverridePayload:
+    """Plain-data override sent from TUI to the apply endpoint."""
+
+    date: str
+    description: str
+    amount: str
+    account: str
+
+
+@dataclass(frozen=True)
 class ApplyImportRequest:
     import_type: ImportType
     csv_file: str
@@ -67,6 +77,29 @@ class ApplyImportRequest:
     start_date: str | None = None
     end_date: str | None = None
     allow_uncommitted: bool | None = None
+    cc_payment_overrides: tuple[TransactionOverridePayload, ...] = ()
+    bank_transfer_overrides: tuple[TransactionOverridePayload, ...] = ()
+
+
+@dataclass(frozen=True)
+class ImportDecisionPayload:
+    """Plain-data ambiguous-decision returned by preflight to the TUI."""
+
+    kind: Literal["cc_payment", "bank_transfer"]
+    pattern: str
+    txn_date: str
+    txn_description: str
+    txn_amount: str
+    candidates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PreflightChequingImportResult:
+    status: Literal["ok", "error"]
+    chequing_type: str | None = None
+    account: str | None = None
+    decisions: tuple[ImportDecisionPayload, ...] = ()
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -292,6 +325,49 @@ def apply_import(request: ApplyImportRequest) -> ApplyImportResult:
     )
 
 
+def _convert_overrides(
+    overrides: tuple[TransactionOverridePayload, ...],
+) -> tuple[chequing_import.TransactionOverride, ...]:
+    from beanbeaver.application.imports.account_discovery import TransactionKey
+
+    return tuple(
+        chequing_import.TransactionOverride(
+            transaction=TransactionKey(date=item.date, description=item.description, amount=item.amount),
+            account=item.account,
+        )
+        for item in overrides
+    )
+
+
+def preflight_chequing_import(
+    *,
+    csv_file: str,
+    selected_account: str | None = None,
+) -> PreflightChequingImportResult:
+    result = chequing_import.preflight_chequing_import(
+        csv_file=csv_file,
+        selected_account=selected_account,
+    )
+    decisions = tuple(
+        ImportDecisionPayload(
+            kind=decision.kind,
+            pattern=decision.pattern,
+            txn_date=decision.transaction.date,
+            txn_description=decision.transaction.description,
+            txn_amount=decision.transaction.amount,
+            candidates=decision.candidates,
+        )
+        for decision in result.decisions
+    )
+    return PreflightChequingImportResult(
+        status=result.status,
+        chequing_type=result.chequing_type,
+        account=result.account,
+        decisions=decisions,
+        error=result.error,
+    )
+
+
 def apply_import_machine_readable(request: ApplyImportRequest) -> ApplyImportResult:
     if request.import_type == "cc":
         result = credit_card_import.run_credit_card_import(
@@ -324,6 +400,9 @@ def apply_import_machine_readable(request: ApplyImportRequest) -> ApplyImportRes
             csv_file=request.csv_file,
             selected_account=request.selected_account,
             allow_uncommitted=request.allow_uncommitted,
+            cc_payment_overrides=_convert_overrides(request.cc_payment_overrides),
+            bank_transfer_overrides=_convert_overrides(request.bank_transfer_overrides),
+            interactive=False,
         ),
         emit_console_output=False,
     )

--- a/cli/api.py
+++ b/cli/api.py
@@ -424,6 +424,70 @@ def cmd_api_apply_import(args: argparse.Namespace) -> None:
     )
 
 
+def _parse_override_payload(raw: object, *, field: str) -> tuple[Any, ...]:
+    from beanbeaver.application.imports.service import TransactionOverridePayload
+
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"Import payload field '{field}' must be a JSON array")
+    parsed: list[TransactionOverridePayload] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Import payload field '{field}[{index}]' must be a JSON object")
+        date = entry.get("date")
+        description = entry.get("description")
+        amount = entry.get("amount")
+        account = entry.get("account")
+        if not isinstance(date, str) or not isinstance(description, str):
+            raise ValueError(f"Import payload field '{field}[{index}]' requires string date/description")
+        if not isinstance(amount, str) or not isinstance(account, str):
+            raise ValueError(f"Import payload field '{field}[{index}]' requires string amount/account")
+        parsed.append(
+            TransactionOverridePayload(
+                date=date,
+                description=description,
+                amount=amount,
+                account=account,
+            )
+        )
+    return tuple(parsed)
+
+
+def cmd_api_preflight_chequing_import(args: argparse.Namespace) -> None:
+    """Run preflight on a chequing CSV and surface ambiguous decisions as JSON."""
+    from beanbeaver.application.imports.service import preflight_chequing_import
+
+    payload = _load_optional_stdin_json()
+    csv_file = payload.get("csv_file")
+    selected_account = payload.get("selected_account")
+    if not isinstance(csv_file, str):
+        raise ValueError("Preflight payload field 'csv_file' must be a string")
+    if selected_account is not None and not isinstance(selected_account, str):
+        raise ValueError("Preflight payload field 'selected_account' must be a string")
+
+    result = preflight_chequing_import(csv_file=csv_file, selected_account=selected_account)
+    _print_json(
+        {
+            "status": result.status,
+            "chequing_type": result.chequing_type,
+            "account": result.account,
+            "error": result.error,
+            "decisions": [
+                {
+                    "kind": decision.kind,
+                    "pattern": decision.pattern,
+                    "txn_date": decision.txn_date,
+                    "txn_description": decision.txn_description,
+                    "txn_amount": decision.txn_amount,
+                    "candidates": list(decision.candidates),
+                }
+                for decision in result.decisions
+            ],
+        }
+    )
+
+
 def cmd_api_import_apply(args: argparse.Namespace) -> None:
     """Apply one statement import with a JSON-only response."""
     from beanbeaver.application.imports.service import ApplyImportRequest, apply_import_machine_readable
@@ -436,6 +500,14 @@ def cmd_api_import_apply(args: argparse.Namespace) -> None:
     start_date = payload.get("start_date")
     end_date = payload.get("end_date")
     allow_uncommitted = payload.get("allow_uncommitted")
+    cc_payment_overrides = _parse_override_payload(
+        payload.get("cc_payment_overrides"),
+        field="cc_payment_overrides",
+    )
+    bank_transfer_overrides = _parse_override_payload(
+        payload.get("bank_transfer_overrides"),
+        field="bank_transfer_overrides",
+    )
 
     if import_type not in {"cc", "chequing"}:
         raise ValueError("Import payload field 'import_type' must be 'cc' or 'chequing'")
@@ -461,6 +533,8 @@ def cmd_api_import_apply(args: argparse.Namespace) -> None:
             start_date=start_date,
             end_date=end_date,
             allow_uncommitted=allow_uncommitted,
+            cc_payment_overrides=cc_payment_overrides,
+            bank_transfer_overrides=bank_transfer_overrides,
         )
     )
     _print_json(

--- a/cli/main.py
+++ b/cli/main.py
@@ -109,6 +109,10 @@ Notes:
     api_subparsers.add_parser("resolve-import-accounts", help="List candidate import accounts from stdin JSON")
     api_subparsers.add_parser("apply-import", help="Apply one statement import from stdin JSON")
     api_subparsers.add_parser("import-apply", help="Apply one statement import with a JSON-only response")
+    api_subparsers.add_parser(
+        "preflight-chequing-import",
+        help="Preflight a chequing CSV and surface ambiguous account decisions as JSON",
+    )
 
     show_receipt_parser = api_subparsers.add_parser("show-receipt", help="Show one staged receipt document as JSON")
     show_receipt_parser.add_argument("path", help="Path to a staged receipt JSON file")
@@ -248,6 +252,8 @@ Notes:
             return _run_legacy_command(cli_api.cmd_api_apply_import, args)
         if args.api_command == "import-apply":
             return _run_legacy_command(cli_api.cmd_api_import_apply, args)
+        if args.api_command == "preflight-chequing-import":
+            return _run_legacy_command(cli_api.cmd_api_preflight_chequing_import, args)
         if args.api_command == "get-config":
             return _run_legacy_command(cli_api.cmd_api_get_config, args)
         if args.api_command == "set-config":

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -452,6 +452,7 @@ enum RightPane {
 enum ImportPaneFocus {
     Routes,
     Accounts,
+    Decisions,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -620,6 +621,84 @@ struct ResolveImportAccountsResponse {
     account_options: Option<Vec<String>>,
     as_of: Option<String>,
     error: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ImportDecisionPayload {
+    kind: String,
+    pattern: String,
+    txn_date: String,
+    txn_description: String,
+    txn_amount: String,
+    candidates: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct PreflightChequingImportResponse {
+    status: String,
+    #[serde(default)]
+    decisions: Vec<ImportDecisionPayload>,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ImportDecisionView {
+    kind: String,
+    pattern: String,
+    txn_date: String,
+    txn_description: String,
+    txn_amount: String,
+    candidates: Vec<String>,
+    selected_candidate: Option<usize>,
+}
+
+impl ImportDecisionView {
+    fn from_payload(payload: ImportDecisionPayload) -> Self {
+        Self {
+            kind: payload.kind,
+            pattern: payload.pattern,
+            txn_date: payload.txn_date,
+            txn_description: payload.txn_description,
+            txn_amount: payload.txn_amount,
+            candidates: payload.candidates,
+            selected_candidate: None,
+        }
+    }
+
+    fn selected_account(&self) -> Option<&str> {
+        self.selected_candidate
+            .and_then(|index| self.candidates.get(index))
+            .map(String::as_str)
+    }
+
+    fn cycle_selection(&mut self) {
+        let len = self.candidates.len();
+        if len == 0 {
+            self.selected_candidate = None;
+            return;
+        }
+        self.selected_candidate = match self.selected_candidate {
+            None => Some(0),
+            Some(index) if index + 1 < len => Some(index + 1),
+            Some(_) => None,
+        };
+    }
+
+    fn display_label(&self) -> String {
+        let kind_label = match self.kind.as_str() {
+            "cc_payment" => "CC payment",
+            "bank_transfer" => "Bank transfer",
+            other => other,
+        };
+        let chosen = match self.selected_account() {
+            Some(account) => account.to_string(),
+            None => format!("<unresolved · {} candidates>", self.candidates.len()),
+        };
+        format!(
+            "{kind_label} '{}' {} {}  →  {}",
+            self.pattern, self.txn_date, self.txn_amount, chosen
+        )
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -981,6 +1060,10 @@ struct ImportPageState {
     account_state: ListState,
     account_as_of: Option<String>,
     account_error: Option<String>,
+    decisions: Vec<ImportDecisionView>,
+    decisions_state: ListState,
+    decisions_error: Option<String>,
+    decisions_loaded_for: Option<(String, String)>,
     last_result: Option<ApplyImportResponse>,
 }
 
@@ -990,6 +1073,8 @@ impl ImportPageState {
         route_state.select(None);
         let mut account_state = ListState::default();
         account_state.select(None);
+        let mut decisions_state = ListState::default();
+        decisions_state.select(None);
         Self {
             routes: Vec::new(),
             route_state,
@@ -1003,8 +1088,56 @@ impl ImportPageState {
             account_state,
             account_as_of: None,
             account_error: None,
+            decisions: Vec::new(),
+            decisions_state,
+            decisions_error: None,
+            decisions_loaded_for: None,
             last_result: None,
         }
+    }
+
+    fn set_decisions(&mut self, decisions: Vec<ImportDecisionView>, key: Option<(String, String)>) {
+        self.decisions = decisions;
+        self.decisions_loaded_for = key;
+        self.decisions_error = None;
+        if self.decisions.is_empty() {
+            self.decisions_state.select(None);
+        } else {
+            self.decisions_state.select(Some(0));
+        }
+    }
+
+    fn clear_decisions(&mut self) {
+        self.decisions.clear();
+        self.decisions_loaded_for = None;
+        self.decisions_error = None;
+        self.decisions_state.select(None);
+    }
+
+    fn move_decisions_selection(&mut self, delta: isize) {
+        let len = self.decisions.len();
+        if len == 0 {
+            self.decisions_state.select(None);
+            return;
+        }
+        let current = self.decisions_state.selected().unwrap_or(0) as isize;
+        let next = (current + delta).clamp(0, (len - 1) as isize) as usize;
+        self.decisions_state.select(Some(next));
+    }
+
+    fn cycle_focused_decision(&mut self) {
+        if let Some(index) = self.decisions_state.selected() {
+            if let Some(decision) = self.decisions.get_mut(index) {
+                decision.cycle_selection();
+            }
+        }
+    }
+
+    fn unresolved_decisions(&self) -> usize {
+        self.decisions
+            .iter()
+            .filter(|decision| decision.selected_account().is_none())
+            .count()
     }
 
     fn selected_route(&self) -> Option<&ImportRouteOption> {
@@ -1065,6 +1198,7 @@ impl ImportPageState {
         self.account_state.select(None);
         self.account_as_of = None;
         self.account_error = None;
+        self.clear_decisions();
     }
 
     fn apply_account_resolution(
@@ -2189,7 +2323,7 @@ impl App {
                 "1 receipts | 2 serve | 3 fava | 4 OCR | 5 imports | s start/create container | x stop container | R restart container | r refresh container status/logs | q quit"
             }
             Page::Imports => {
-                "1 receipts | 2 serve | 3 fava | 4 OCR | 5 imports | r load routes | h/l or Tab switch pane | j/k move | Enter reload accounts | v view csv | x trash csv | a apply import | u toggle allow-uncommitted | q quit"
+                "1 receipts | 2 serve | 3 fava | 4 OCR | 5 imports | r load routes | h/l or Tab cycle Routes/Accounts/Decisions | j/k move | Enter cycles decision pick (or reload) | v view csv | x trash csv | a apply import | u toggle allow-uncommitted | q quit"
             }
         }
     }
@@ -2674,6 +2808,41 @@ impl App {
                 .apply_account_resolution(account_resolution, preferred_account.as_deref()),
             None => self.imports_state.clear_account_resolution(),
         }
+        self.refresh_import_decisions()?;
+        Ok(())
+    }
+
+    fn refresh_import_decisions(&mut self) -> AppResult<()> {
+        let Some(route) = self.imports_state.selected_route().cloned() else {
+            self.imports_state.clear_decisions();
+            return Ok(());
+        };
+        if route.import_type != "chequing" {
+            self.imports_state.clear_decisions();
+            return Ok(());
+        }
+        let Some(account) = self.imports_state.selected_account().map(str::to_string) else {
+            self.imports_state.clear_decisions();
+            return Ok(());
+        };
+        let key = (route.source_path.clone(), account.clone());
+        if self.imports_state.decisions_loaded_for.as_ref() == Some(&key) {
+            return Ok(());
+        }
+        let response = backend_preflight_chequing_import(&route.csv_file, Some(&account))?;
+        if response.status != "ok" {
+            self.imports_state.decisions.clear();
+            self.imports_state.decisions_state.select(None);
+            self.imports_state.decisions_error = response.error.clone();
+            self.imports_state.decisions_loaded_for = Some(key);
+            return Ok(());
+        }
+        let decisions: Vec<ImportDecisionView> = response
+            .decisions
+            .into_iter()
+            .map(ImportDecisionView::from_payload)
+            .collect();
+        self.imports_state.set_decisions(decisions, Some(key));
         Ok(())
     }
 
@@ -2717,12 +2886,41 @@ impl App {
             return Ok(());
         };
         let selected_account = self.imports_state.selected_account().map(ToOwned::to_owned);
+        let unresolved = self.imports_state.unresolved_decisions();
+        if unresolved > 0 {
+            self.set_status(format!(
+                "Apply blocked: {} unresolved account decision(s). Focus Decisions pane (Tab) and press Enter to pick.",
+                unresolved
+            ));
+            return Ok(());
+        }
+        let mut cc_overrides: Vec<ImportOverridePayload> = Vec::new();
+        let mut bank_overrides: Vec<ImportOverridePayload> = Vec::new();
+        for decision in &self.imports_state.decisions {
+            let account = match decision.selected_account() {
+                Some(a) => a.to_string(),
+                None => continue,
+            };
+            let payload = ImportOverridePayload {
+                date: decision.txn_date.clone(),
+                description: decision.txn_description.clone(),
+                amount: decision.txn_amount.clone(),
+                account,
+            };
+            match decision.kind.as_str() {
+                "cc_payment" => cc_overrides.push(payload),
+                "bank_transfer" => bank_overrides.push(payload),
+                _ => {}
+            }
+        }
         let response = backend_apply_import(
             &route.import_type,
             &route.csv_file,
             &route.importer_id,
             selected_account.as_deref(),
             self.imports_state.allow_uncommitted,
+            &cc_overrides,
+            &bank_overrides,
         )?;
         let status = match response.status.as_str() {
             "ok" => response
@@ -3308,6 +3506,8 @@ fn backend_apply_import(
     importer_id: &str,
     selected_account: Option<&str>,
     allow_uncommitted: bool,
+    cc_payment_overrides: &[ImportOverridePayload],
+    bank_transfer_overrides: &[ImportOverridePayload],
 ) -> AppResult<ApplyImportResponse> {
     let payload = serde_json::json!({
         "import_type": import_type,
@@ -3315,12 +3515,37 @@ fn backend_apply_import(
         "importer_id": importer_id,
         "selected_account": selected_account,
         "allow_uncommitted": allow_uncommitted,
+        "cc_payment_overrides": cc_payment_overrides,
+        "bank_transfer_overrides": bank_transfer_overrides,
     });
     let stdout = run_backend_with_input(
         &["api", "import-apply"],
         Some(&serde_json::to_string(&payload)?),
     )?;
     Ok(serde_json::from_str(&stdout)?)
+}
+
+fn backend_preflight_chequing_import(
+    csv_file: &str,
+    selected_account: Option<&str>,
+) -> AppResult<PreflightChequingImportResponse> {
+    let payload = serde_json::json!({
+        "csv_file": csv_file,
+        "selected_account": selected_account,
+    });
+    let stdout = run_backend_with_input(
+        &["api", "preflight-chequing-import"],
+        Some(&serde_json::to_string(&payload)?),
+    )?;
+    Ok(serde_json::from_str(&stdout)?)
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct ImportOverridePayload {
+    date: String,
+    description: String,
+    amount: String,
+    account: String,
 }
 
 fn backend_set_config(project_root: &str) -> AppResult<ConfigResponse> {
@@ -4360,11 +4585,18 @@ fn render_ocr_page(frame: &mut ratatui::Frame<'_>, app: &App, area: ratatui::lay
 fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: ratatui::layout::Rect) {
     let sections = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(6), Constraint::Min(10)])
+        .constraints([Constraint::Length(7), Constraint::Min(10)])
         .split(area);
 
+    let total_decisions = app.imports_state.decisions.len();
+    let unresolved_decisions = app.imports_state.unresolved_decisions();
+    let decisions_summary = if total_decisions == 0 {
+        "none".to_string()
+    } else {
+        format!("{total_decisions} total, {unresolved_decisions} unresolved")
+    };
     let summary = Paragraph::new(format!(
-        "Detected routes: {}\nWorking tree: {}\nAllow import with uncommitted changes: {}\nSelected route: {}",
+        "Detected routes: {}\nWorking tree: {}\nAllow import with uncommitted changes: {}\nSelected route: {}\nDecisions: {}",
         app.imports_state.routes.len(),
         if app.imports_state.has_uncommitted_changes {
             "uncommitted changes detected"
@@ -4379,7 +4611,8 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
         app.imports_state
             .selected_route()
             .map(|route| route.csv_file.as_str())
-            .unwrap_or("<none>")
+            .unwrap_or("<none>"),
+        decisions_summary,
     ))
     .block(
         Block::default()
@@ -4395,7 +4628,11 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
         .split(sections[1]);
     let right = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(10), Constraint::Min(8)])
+        .constraints([
+            Constraint::Length(7),
+            Constraint::Min(6),
+            Constraint::Length(10),
+        ])
         .split(body[1]);
 
     let route_items: Vec<ListItem> = app
@@ -4445,6 +4682,40 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
         .highlight_symbol(">> ");
     frame.render_stateful_widget(accounts, right[0], &mut app.imports_state.account_state);
 
+    let unresolved = app.imports_state.unresolved_decisions();
+    let total = app.imports_state.decisions.len();
+    let decisions_title = if let Some(error) = app.imports_state.decisions_error.as_ref() {
+        format!("Decisions (error: {})", truncate_for_title(error, 60))
+    } else if total == 0 {
+        "Decisions (none)".to_string()
+    } else {
+        format!("Decisions ({total} total · {unresolved} unresolved · Enter cycles)")
+    };
+    let decision_items: Vec<ListItem> = app
+        .imports_state
+        .decisions
+        .iter()
+        .map(|decision| ListItem::new(Line::from(decision.display_label())))
+        .collect();
+    let decisions_widget = List::new(decision_items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(decisions_title)
+                .border_style(if app.imports_state.focus == ImportPaneFocus::Decisions {
+                    Style::default().fg(Color::Yellow)
+                } else {
+                    Style::default()
+                }),
+        )
+        .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
+        .highlight_symbol(">> ");
+    frame.render_stateful_widget(
+        decisions_widget,
+        right[1],
+        &mut app.imports_state.decisions_state,
+    );
+
     let details = Paragraph::new(Text::from(
         app.imports_state
             .detail_lines()
@@ -4458,7 +4729,18 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
             .title("Import Details"),
     )
     .wrap(Wrap { trim: false });
-    frame.render_widget(details, right[1]);
+    frame.render_widget(details, right[2]);
+}
+
+fn truncate_for_title(text: &str, max_len: usize) -> String {
+    let cleaned = text.replace('\n', " ");
+    if cleaned.chars().count() <= max_len {
+        cleaned
+    } else {
+        let mut truncated: String = cleaned.chars().take(max_len.saturating_sub(1)).collect();
+        truncated.push('…');
+        truncated
+    }
 }
 
 fn render_review_screen(
@@ -5532,38 +5814,71 @@ fn run_app(
                     (KeyCode::Tab, _)
                     | (KeyCode::Char('l'), KeyModifiers::NONE)
                     | (KeyCode::Right, _) => {
-                        app.imports_state.focus = ImportPaneFocus::Accounts;
+                        app.imports_state.focus = match app.imports_state.focus {
+                            ImportPaneFocus::Routes => ImportPaneFocus::Accounts,
+                            ImportPaneFocus::Accounts => ImportPaneFocus::Decisions,
+                            ImportPaneFocus::Decisions => ImportPaneFocus::Routes,
+                        };
                     }
                     (KeyCode::BackTab, _)
                     | (KeyCode::Char('h'), KeyModifiers::NONE)
                     | (KeyCode::Left, _) => {
-                        app.imports_state.focus = ImportPaneFocus::Routes;
+                        app.imports_state.focus = match app.imports_state.focus {
+                            ImportPaneFocus::Routes => ImportPaneFocus::Decisions,
+                            ImportPaneFocus::Accounts => ImportPaneFocus::Routes,
+                            ImportPaneFocus::Decisions => ImportPaneFocus::Accounts,
+                        };
                     }
                     (KeyCode::Down, _) | (KeyCode::Char('j'), KeyModifiers::NONE) => {
-                        if app.imports_state.focus == ImportPaneFocus::Routes {
-                            if let Err(error) = app.move_import_route_selection(1) {
-                                app.set_error(error.to_string());
+                        match app.imports_state.focus {
+                            ImportPaneFocus::Routes => {
+                                if let Err(error) = app.move_import_route_selection(1) {
+                                    app.set_error(error.to_string());
+                                }
                             }
-                        } else {
-                            app.imports_state.move_account_selection(1);
+                            ImportPaneFocus::Accounts => {
+                                app.imports_state.move_account_selection(1);
+                            }
+                            ImportPaneFocus::Decisions => {
+                                app.imports_state.move_decisions_selection(1);
+                            }
                         }
                     }
                     (KeyCode::Up, _) | (KeyCode::Char('k'), KeyModifiers::NONE) => {
-                        if app.imports_state.focus == ImportPaneFocus::Routes {
-                            if let Err(error) = app.move_import_route_selection(-1) {
-                                app.set_error(error.to_string());
+                        match app.imports_state.focus {
+                            ImportPaneFocus::Routes => {
+                                if let Err(error) = app.move_import_route_selection(-1) {
+                                    app.set_error(error.to_string());
+                                }
                             }
-                        } else {
-                            app.imports_state.move_account_selection(-1);
+                            ImportPaneFocus::Accounts => {
+                                app.imports_state.move_account_selection(-1);
+                            }
+                            ImportPaneFocus::Decisions => {
+                                app.imports_state.move_decisions_selection(-1);
+                            }
                         }
                     }
-                    (KeyCode::Enter, _) => {
-                        if let Err(error) = app.resolve_selected_import_accounts() {
-                            app.set_error(error.to_string());
-                        } else {
-                            app.set_status("Reloaded account choices for selected statement");
+                    (KeyCode::Enter, _) => match app.imports_state.focus {
+                        ImportPaneFocus::Decisions => {
+                            app.imports_state.cycle_focused_decision();
                         }
-                    }
+                        ImportPaneFocus::Accounts => {
+                            app.imports_state.clear_decisions();
+                            if let Err(error) = app.refresh_import_decisions() {
+                                app.set_error(error.to_string());
+                            } else {
+                                app.set_status("Reloaded import decisions for selected account");
+                            }
+                        }
+                        ImportPaneFocus::Routes => {
+                            if let Err(error) = app.resolve_selected_import_accounts() {
+                                app.set_error(error.to_string());
+                            } else {
+                                app.set_status("Reloaded account choices for selected statement");
+                            }
+                        }
+                    },
                     (KeyCode::Char('u'), KeyModifiers::NONE) => {
                         app.imports_state.allow_uncommitted = !app.imports_state.allow_uncommitted;
                         app.set_status(format!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1125,6 +1125,22 @@ impl ImportPageState {
         self.decision_picker = Some(DecisionPickerState::new(index, decision.selected_candidate));
     }
 
+    fn first_unresolved_index(&self) -> Option<usize> {
+        self.decisions
+            .iter()
+            .position(|decision| decision.selected_account().is_none())
+    }
+
+    fn jump_to_first_unresolved_and_open(&mut self) -> bool {
+        let Some(index) = self.first_unresolved_index() else {
+            return false;
+        };
+        self.focus = ImportPaneFocus::Decisions;
+        self.decisions_state.select(Some(index));
+        self.open_decision_picker();
+        true
+    }
+
     fn close_decision_picker(&mut self) {
         self.decision_picker = None;
     }
@@ -2868,12 +2884,10 @@ impl App {
         };
         if route.import_type != "chequing" {
             self.imports_state.clear_decisions();
-            self.set_status("Preflight skipped: only chequing imports support per-row decisions");
             return Ok(());
         }
         let Some(account) = self.imports_state.selected_account().map(str::to_string) else {
             self.imports_state.clear_decisions();
-            self.set_status("Preflight skipped: no chequing account selected yet");
             return Ok(());
         };
         let key = (route.source_path.clone(), account.clone());
@@ -6023,26 +6037,32 @@ fn run_app(
                             }
                         }
                     }
-                    (KeyCode::Enter, _) => match app.imports_state.focus {
-                        ImportPaneFocus::Decisions => {
+                    (KeyCode::Enter, _) => {
+                        if app.imports_state.focus == ImportPaneFocus::Decisions {
                             app.imports_state.open_decision_picker();
-                        }
-                        ImportPaneFocus::Accounts => {
-                            app.imports_state.clear_decisions();
-                            if let Err(error) = app.refresh_import_decisions() {
-                                app.set_error(error.to_string());
-                            } else {
-                                app.set_status("Reloaded import decisions for selected account");
+                        } else if app.imports_state.jump_to_first_unresolved_and_open() {
+                            app.set_status("Pick an account for this ambiguous transaction (Esc to cancel)");
+                        } else {
+                            match app.imports_state.focus {
+                                ImportPaneFocus::Accounts => {
+                                    app.imports_state.clear_decisions();
+                                    if let Err(error) = app.refresh_import_decisions() {
+                                        app.set_error(error.to_string());
+                                    } else {
+                                        app.set_status("Reloaded import decisions for selected account");
+                                    }
+                                }
+                                ImportPaneFocus::Routes => {
+                                    if let Err(error) = app.resolve_selected_import_accounts() {
+                                        app.set_error(error.to_string());
+                                    } else {
+                                        app.set_status("Reloaded account choices for selected statement");
+                                    }
+                                }
+                                ImportPaneFocus::Decisions => unreachable!(),
                             }
                         }
-                        ImportPaneFocus::Routes => {
-                            if let Err(error) = app.resolve_selected_import_accounts() {
-                                app.set_error(error.to_string());
-                            } else {
-                                app.set_status("Reloaded account choices for selected statement");
-                            }
-                        }
-                    },
+                    }
                     (KeyCode::Char('u'), KeyModifiers::NONE) => {
                         app.imports_state.allow_uncommitted = !app.imports_state.allow_uncommitted;
                         app.set_status(format!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2868,10 +2868,12 @@ impl App {
         };
         if route.import_type != "chequing" {
             self.imports_state.clear_decisions();
+            self.set_status("Preflight skipped: only chequing imports support per-row decisions");
             return Ok(());
         }
         let Some(account) = self.imports_state.selected_account().map(str::to_string) else {
             self.imports_state.clear_decisions();
+            self.set_status("Preflight skipped: no chequing account selected yet");
             return Ok(());
         };
         let key = (route.source_path.clone(), account.clone());
@@ -2884,6 +2886,10 @@ impl App {
             self.imports_state.decisions_state.select(None);
             self.imports_state.decisions_error = response.error.clone();
             self.imports_state.decisions_loaded_for = Some(key);
+            self.set_status(format!(
+                "Preflight failed: {}",
+                response.error.as_deref().unwrap_or("unknown error")
+            ));
             return Ok(());
         }
         let decisions: Vec<ImportDecisionView> = response
@@ -2891,7 +2897,15 @@ impl App {
             .into_iter()
             .map(ImportDecisionView::from_payload)
             .collect();
+        let count = decisions.len();
         self.imports_state.set_decisions(decisions, Some(key));
+        if count == 0 {
+            self.set_status("Preflight ok: no ambiguous decisions to resolve");
+        } else {
+            self.set_status(format!(
+                "Preflight ok: {count} ambiguous decision(s) — focus Decisions pane (Tab) and press Enter to pick"
+            ));
+        }
         Ok(())
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -671,19 +671,6 @@ impl ImportDecisionView {
             .map(String::as_str)
     }
 
-    fn cycle_selection(&mut self) {
-        let len = self.candidates.len();
-        if len == 0 {
-            self.selected_candidate = None;
-            return;
-        }
-        self.selected_candidate = match self.selected_candidate {
-            None => Some(0),
-            Some(index) if index + 1 < len => Some(index + 1),
-            Some(_) => None,
-        };
-    }
-
     fn display_label(&self) -> String {
         let kind_label = match self.kind.as_str() {
             "cc_payment" => "CC payment",
@@ -1047,6 +1034,33 @@ impl TextInputState {
 }
 
 #[derive(Clone, Debug)]
+struct DecisionPickerState {
+    decision_index: usize,
+    list_state: ListState,
+}
+
+impl DecisionPickerState {
+    fn new(decision_index: usize, initial_selection: Option<usize>) -> Self {
+        let mut list_state = ListState::default();
+        list_state.select(initial_selection.or(Some(0)));
+        Self {
+            decision_index,
+            list_state,
+        }
+    }
+
+    fn move_selection(&mut self, delta: isize, len: usize) {
+        if len == 0 {
+            self.list_state.select(None);
+            return;
+        }
+        let current = self.list_state.selected().unwrap_or(0) as isize;
+        let next = (current + delta).clamp(0, (len - 1) as isize) as usize;
+        self.list_state.select(Some(next));
+    }
+}
+
+#[derive(Clone, Debug)]
 struct ImportPageState {
     routes: Vec<ImportRouteOption>,
     route_state: ListState,
@@ -1064,6 +1078,7 @@ struct ImportPageState {
     decisions_state: ListState,
     decisions_error: Option<String>,
     decisions_loaded_for: Option<(String, String)>,
+    decision_picker: Option<DecisionPickerState>,
     last_result: Option<ApplyImportResponse>,
 }
 
@@ -1092,7 +1107,48 @@ impl ImportPageState {
             decisions_state,
             decisions_error: None,
             decisions_loaded_for: None,
+            decision_picker: None,
             last_result: None,
+        }
+    }
+
+    fn open_decision_picker(&mut self) {
+        let Some(index) = self.decisions_state.selected() else {
+            return;
+        };
+        let Some(decision) = self.decisions.get(index) else {
+            return;
+        };
+        if decision.candidates.is_empty() {
+            return;
+        }
+        self.decision_picker = Some(DecisionPickerState::new(index, decision.selected_candidate));
+    }
+
+    fn close_decision_picker(&mut self) {
+        self.decision_picker = None;
+    }
+
+    fn confirm_decision_picker(&mut self) {
+        let Some(picker) = self.decision_picker.take() else {
+            return;
+        };
+        let Some(selection) = picker.list_state.selected() else {
+            return;
+        };
+        if let Some(decision) = self.decisions.get_mut(picker.decision_index) {
+            if selection < decision.candidates.len() {
+                decision.selected_candidate = Some(selection);
+            }
+        }
+    }
+
+    fn clear_decision_picker_selection(&mut self) {
+        let Some(picker) = self.decision_picker.take() else {
+            return;
+        };
+        if let Some(decision) = self.decisions.get_mut(picker.decision_index) {
+            decision.selected_candidate = None;
         }
     }
 
@@ -1112,6 +1168,7 @@ impl ImportPageState {
         self.decisions_loaded_for = None;
         self.decisions_error = None;
         self.decisions_state.select(None);
+        self.decision_picker = None;
     }
 
     fn move_decisions_selection(&mut self, delta: isize) {
@@ -1123,14 +1180,6 @@ impl ImportPageState {
         let current = self.decisions_state.selected().unwrap_or(0) as isize;
         let next = (current + delta).clamp(0, (len - 1) as isize) as usize;
         self.decisions_state.select(Some(next));
-    }
-
-    fn cycle_focused_decision(&mut self) {
-        if let Some(index) = self.decisions_state.selected() {
-            if let Some(decision) = self.decisions.get_mut(index) {
-                decision.cycle_selection();
-            }
-        }
     }
 
     fn unresolved_decisions(&self) -> usize {
@@ -2323,7 +2372,7 @@ impl App {
                 "1 receipts | 2 serve | 3 fava | 4 OCR | 5 imports | s start/create container | x stop container | R restart container | r refresh container status/logs | q quit"
             }
             Page::Imports => {
-                "1 receipts | 2 serve | 3 fava | 4 OCR | 5 imports | r load routes | h/l or Tab cycle Routes/Accounts/Decisions | j/k move | Enter cycles decision pick (or reload) | v view csv | x trash csv | a apply import | u toggle allow-uncommitted | q quit"
+                "1 receipts | 2 serve | 3 fava | 4 OCR | 5 imports | r load routes | h/l or Tab cycle Routes/Accounts/Decisions | j/k move | Enter opens picker (Routes: reload accounts) | v view csv | x trash csv | a apply import | u toggle allow-uncommitted | q quit"
             }
         }
     }
@@ -4355,6 +4404,9 @@ fn render_app(frame: &mut ratatui::Frame<'_>, app: &mut App) {
     if let Some(match_state) = &mut app.match_state {
         render_match_modal(frame, match_state);
     }
+    if app.imports_state.decision_picker.is_some() {
+        render_decision_picker_modal(frame, &mut app.imports_state);
+    }
 }
 
 fn render_receipts_page(
@@ -4689,7 +4741,7 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
     } else if total == 0 {
         "Decisions (none)".to_string()
     } else {
-        format!("Decisions ({total} total · {unresolved} unresolved · Enter cycles)")
+        format!("Decisions ({total} total · {unresolved} unresolved · Enter to pick)")
     };
     let decision_items: Vec<ListItem> = app
         .imports_state
@@ -5247,6 +5299,69 @@ fn render_match_modal(frame: &mut ratatui::Frame<'_>, match_state: &mut MatchSta
     frame.render_widget(help, rows[3]);
 }
 
+fn render_decision_picker_modal(
+    frame: &mut ratatui::Frame<'_>,
+    imports_state: &mut ImportPageState,
+) {
+    let Some(picker) = imports_state.decision_picker.as_mut() else {
+        return;
+    };
+    let Some(decision) = imports_state.decisions.get(picker.decision_index) else {
+        return;
+    };
+
+    let popup = centered_rect(72, 16, frame.area());
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Pick account for ambiguous transaction")
+            .style(popup_style()),
+        popup,
+    );
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),
+            Constraint::Min(4),
+            Constraint::Length(2),
+        ])
+        .split(popup);
+
+    let kind_label = match decision.kind.as_str() {
+        "cc_payment" => "CC payment",
+        "bank_transfer" => "Bank transfer",
+        other => other,
+    };
+    let summary = Paragraph::new(format!(
+        "Kind: {kind_label}\nPattern: {}\nDate: {}    Amount: {}\nDescription: {}",
+        decision.pattern, decision.txn_date, decision.txn_amount, decision.txn_description,
+    ))
+    .style(Style::default().fg(Color::Gray))
+    .wrap(Wrap { trim: true });
+    frame.render_widget(summary, rows[0]);
+
+    let items: Vec<ListItem> = decision
+        .candidates
+        .iter()
+        .map(|account| ListItem::new(Line::from(account.clone())))
+        .collect();
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!("Candidates ({})", decision.candidates.len())),
+        )
+        .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
+        .highlight_symbol(">> ");
+    frame.render_stateful_widget(list, rows[1], &mut picker.list_state);
+
+    let help =
+        Paragraph::new("Enter pick  |  c clear selection  |  Esc cancel  |  j/k move").wrap(Wrap { trim: true });
+    frame.render_widget(help, rows[2]);
+}
+
 fn centered_rect(
     width_percent: u16,
     height: u16,
@@ -5587,6 +5702,41 @@ fn run_app(
             continue;
         }
 
+        if app.imports_state.decision_picker.is_some() {
+            let candidates_len = app
+                .imports_state
+                .decision_picker
+                .as_ref()
+                .and_then(|picker| app.imports_state.decisions.get(picker.decision_index))
+                .map(|decision| decision.candidates.len())
+                .unwrap_or(0);
+            match key.code {
+                KeyCode::Esc => {
+                    app.imports_state.close_decision_picker();
+                    app.set_status("Decision picker cancelled");
+                }
+                KeyCode::Enter => {
+                    app.imports_state.confirm_decision_picker();
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if let Some(picker) = app.imports_state.decision_picker.as_mut() {
+                        picker.move_selection(1, candidates_len);
+                    }
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    if let Some(picker) = app.imports_state.decision_picker.as_mut() {
+                        picker.move_selection(-1, candidates_len);
+                    }
+                }
+                KeyCode::Char('c') => {
+                    app.imports_state.clear_decision_picker_selection();
+                    app.set_status("Cleared selection for this decision");
+                }
+                _ => {}
+            }
+            continue;
+        }
+
         if app.match_state.is_some() {
             match key.code {
                 KeyCode::Esc => {
@@ -5861,7 +6011,7 @@ fn run_app(
                     }
                     (KeyCode::Enter, _) => match app.imports_state.focus {
                         ImportPaneFocus::Decisions => {
-                            app.imports_state.cycle_focused_decision();
+                            app.imports_state.open_decision_picker();
                         }
                         ImportPaneFocus::Accounts => {
                             app.imports_state.clear_decisions();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -574,7 +574,11 @@ struct ImportRouteOption {
     source_path: String,
     import_type: String,
     importer_id: String,
+    #[serde(default)]
+    #[allow(dead_code)]
     rule_id: String,
+    #[serde(default)]
+    #[allow(dead_code)]
     stage: u32,
 }
 
@@ -691,17 +695,7 @@ impl ImportDecisionView {
 #[derive(Clone, Debug, Deserialize)]
 struct ApplyImportResponse {
     status: String,
-    import_type: String,
-    result_file_path: Option<String>,
-    result_file_name: Option<String>,
-    account: Option<String>,
-    start_date: Option<String>,
-    end_date: Option<String>,
     error: Option<String>,
-    #[serde(default)]
-    warnings: Vec<String>,
-    #[serde(default)]
-    validation_errors: Vec<String>,
     summary: Option<String>,
 }
 
@@ -1079,7 +1073,6 @@ struct ImportPageState {
     decisions_error: Option<String>,
     decisions_loaded_for: Option<(String, String)>,
     decision_picker: Option<DecisionPickerState>,
-    last_result: Option<ApplyImportResponse>,
 }
 
 impl ImportPageState {
@@ -1108,7 +1101,6 @@ impl ImportPageState {
             decisions_error: None,
             decisions_loaded_for: None,
             decision_picker: None,
-            last_result: None,
         }
     }
 
@@ -1288,108 +1280,6 @@ impl ImportPageState {
         }
     }
 
-    fn detail_lines(&self) -> Vec<String> {
-        let mut lines = vec![
-            format!(
-                "Planner Status: {}",
-                match self.planner_status.as_str() {
-                    "not_loaded" => "not loaded (press `r` to load routes)",
-                    other => other,
-                }
-            ),
-            format!(
-                "Git Working Tree: {}",
-                if self.has_uncommitted_changes {
-                    "uncommitted changes detected"
-                } else {
-                    "clean"
-                }
-            ),
-            format!(
-                "Allow Import With Uncommitted Changes: {}",
-                if self.allow_uncommitted { "yes" } else { "no" }
-            ),
-        ];
-
-        if let Some(error) = &self.planner_error {
-            lines.push(String::new());
-            lines.push("Planner Error:".to_string());
-            lines.extend(error.lines().map(ToOwned::to_owned));
-        }
-
-        if let Some(route) = self.selected_route() {
-            lines.push(String::new());
-            lines.push("Selected Route".to_string());
-            lines.push(format!("CSV: {}", route.csv_file));
-            lines.push(format!("Source: {}", route.source_path));
-            lines.push(format!("Type: {}", route.import_type_label()));
-            lines.push(format!("Importer: {}", route.importer_id));
-            lines.push(format!("Rule: {}", route.rule_id));
-            lines.push(format!("Stage: {}", route.stage));
-        }
-
-        if self.account_label.is_some() || self.account_error.is_some() {
-            lines.push(String::new());
-            lines.push("Account Resolution".to_string());
-            if let Some(label) = &self.account_label {
-                lines.push(format!("Label: {label}"));
-            }
-            if let Some(as_of) = &self.account_as_of {
-                lines.push(format!("As Of: {as_of}"));
-            }
-            if let Some(account) = self.selected_account() {
-                lines.push(format!("Selected Account: {account}"));
-            }
-            if let Some(error) = &self.account_error {
-                lines.push("Error:".to_string());
-                lines.extend(error.lines().map(ToOwned::to_owned));
-            }
-        }
-
-        if let Some(result) = &self.last_result {
-            lines.push(String::new());
-            lines.push("Last Import Result".to_string());
-            lines.push(format!("Status: {}", result.status));
-            lines.push(format!("Import Type: {}", result.import_type));
-            if let Some(summary) = &result.summary {
-                lines.push(format!("Summary: {summary}"));
-            }
-            if let Some(account) = &result.account {
-                lines.push(format!("Account: {account}"));
-            }
-            if let Some(start_date) = &result.start_date {
-                lines.push(format!("Start Date: {start_date}"));
-            }
-            if let Some(end_date) = &result.end_date {
-                lines.push(format!("End Date: {end_date}"));
-            }
-            if let Some(path) = &result.result_file_path {
-                lines.push(format!("Result File: {path}"));
-            }
-            if let Some(name) = &result.result_file_name {
-                lines.push(format!("Result File Name: {name}"));
-            }
-            if let Some(error) = &result.error {
-                lines.push("Error:".to_string());
-                lines.extend(error.lines().map(ToOwned::to_owned));
-            }
-            if !result.warnings.is_empty() {
-                lines.push("Warnings:".to_string());
-                lines.extend(result.warnings.iter().map(|warning| format!("- {warning}")));
-            }
-            if !result.validation_errors.is_empty() {
-                lines.push("Validation Errors:".to_string());
-                lines.extend(
-                    result
-                        .validation_errors
-                        .iter()
-                        .map(|error| format!("- {error}")),
-                );
-            }
-        }
-
-        lines
-    }
 }
 
 struct ReviewState {
@@ -3010,7 +2900,7 @@ impl App {
                 .clone()
                 .unwrap_or_else(|| format!("Import failed: {}", response.status)),
         };
-        self.imports_state.last_result = Some(response);
+        let _ = response;
         self.refresh_imports_page()?;
         self.set_status(status);
         Ok(())
@@ -4700,17 +4590,13 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
     frame.render_widget(summary, sections[0]);
 
     let body = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
-        .split(sections[1]);
-    let right = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(7),
-            Constraint::Min(6),
-            Constraint::Length(10),
-        ])
-        .split(body[1]);
+        .constraints([Constraint::Length(8), Constraint::Min(6)])
+        .split(sections[1]);
+    let top_row = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(body[0]);
 
     let route_items: Vec<ListItem> = app
         .imports_state
@@ -4731,7 +4617,7 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
         )
         .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
         .highlight_symbol(">> ");
-    frame.render_stateful_widget(routes, body[0], &mut app.imports_state.route_state);
+    frame.render_stateful_widget(routes, top_row[0], &mut app.imports_state.route_state);
 
     let account_items: Vec<ListItem> = app
         .imports_state
@@ -4757,7 +4643,7 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
         )
         .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
         .highlight_symbol(">> ");
-    frame.render_stateful_widget(accounts, right[0], &mut app.imports_state.account_state);
+    frame.render_stateful_widget(accounts, top_row[1], &mut app.imports_state.account_state);
 
     let unresolved = app.imports_state.unresolved_decisions();
     let total = app.imports_state.decisions.len();
@@ -4789,24 +4675,9 @@ fn render_imports_page(frame: &mut ratatui::Frame<'_>, app: &mut App, area: rata
         .highlight_symbol(">> ");
     frame.render_stateful_widget(
         decisions_widget,
-        right[1],
+        body[1],
         &mut app.imports_state.decisions_state,
     );
-
-    let details = Paragraph::new(Text::from(
-        app.imports_state
-            .detail_lines()
-            .into_iter()
-            .map(Line::from)
-            .collect::<Vec<_>>(),
-    ))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title("Import Details"),
-    )
-    .wrap(Wrap { trim: false });
-    frame.render_widget(details, right[2]);
 }
 
 fn truncate_for_title(text: &str, max_len: usize) -> String {
@@ -6585,58 +6456,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn import_page_detail_lines_include_last_result_and_warnings() {
-        let mut state = ImportPageState::new();
-        state.planner_status = "ready".to_string();
-        state.has_uncommitted_changes = true;
-        state.allow_uncommitted = true;
-        state.set_routes(
-            vec![ImportRouteOption {
-                csv_file: "statement.csv".to_string(),
-                source_path: "/tmp/statement.csv".to_string(),
-                import_type: "cc".to_string(),
-                importer_id: "bmo".to_string(),
-                rule_id: "cc-bmo-statement".to_string(),
-                stage: 1,
-            }],
-            None,
-        );
-        state.apply_account_resolution(
-            ResolveImportAccountsResponse {
-                status: "ready".to_string(),
-                _import_type: "cc".to_string(),
-                _csv_file: "statement.csv".to_string(),
-                _importer_id: "bmo".to_string(),
-                account_label: Some("BMO credit card".to_string()),
-                account_options: Some(vec!["Liabilities:CreditCard:Primary:BMO:CardA".to_string()]),
-                as_of: Some("2026-03-04".to_string()),
-                error: None,
-            },
-            None,
-        );
-        state.last_result = Some(ApplyImportResponse {
-            status: "ok".to_string(),
-            import_type: "cc".to_string(),
-            result_file_path: Some("/tmp/carda_0304_0304.beancount".to_string()),
-            result_file_name: Some("carda_0304_0304.beancount".to_string()),
-            account: Some("Liabilities:CreditCard:Primary:BMO:CardA".to_string()),
-            start_date: Some("0304".to_string()),
-            end_date: Some("0304".to_string()),
-            error: None,
-            warnings: vec!["Ledger validation found errors after import.".to_string()],
-            validation_errors: vec!["Validation error 1".to_string()],
-            summary: Some("Import complete: /tmp/carda_0304_0304.beancount".to_string()),
-        });
-
-        let rendered = state.detail_lines().join("\n");
-
-        assert!(rendered.contains("Planner Status: ready"));
-        assert!(rendered.contains("Git Working Tree: uncommitted changes detected"));
-        assert!(rendered.contains("Selected Route"));
-        assert!(rendered.contains("Selected Account: Liabilities:CreditCard:Primary:BMO:CardA"));
-        assert!(rendered.contains("Last Import Result"));
-        assert!(rendered.contains("Warnings:"));
-        assert!(rendered.contains("Validation Errors:"));
-    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1145,18 +1145,15 @@ impl ImportPageState {
         self.decision_picker = None;
     }
 
-    fn confirm_decision_picker(&mut self) {
-        let Some(picker) = self.decision_picker.take() else {
-            return;
-        };
-        let Some(selection) = picker.list_state.selected() else {
-            return;
-        };
-        if let Some(decision) = self.decisions.get_mut(picker.decision_index) {
-            if selection < decision.candidates.len() {
-                decision.selected_candidate = Some(selection);
-            }
+    fn confirm_decision_picker(&mut self) -> Option<String> {
+        let picker = self.decision_picker.take()?;
+        let selection = picker.list_state.selected()?;
+        let decision = self.decisions.get_mut(picker.decision_index)?;
+        if selection >= decision.candidates.len() {
+            return None;
         }
+        decision.selected_candidate = Some(selection);
+        decision.candidates.get(selection).cloned()
     }
 
     fn clear_decision_picker_selection(&mut self) {
@@ -5366,27 +5363,30 @@ fn render_decision_picker_modal(
         "Kind: {kind_label}\nPattern: {}\nDate: {}    Amount: {}\nDescription: {}",
         decision.pattern, decision.txn_date, decision.txn_amount, decision.txn_description,
     ))
-    .style(Style::default().fg(Color::Gray))
+    .style(popup_style())
     .wrap(Wrap { trim: true });
     frame.render_widget(summary, rows[0]);
 
     let items: Vec<ListItem> = decision
         .candidates
         .iter()
-        .map(|account| ListItem::new(Line::from(account.clone())))
+        .map(|account| ListItem::new(Line::from(account.clone())).style(popup_style()))
         .collect();
     let list = List::new(items)
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(format!("Candidates ({})", decision.candidates.len())),
+                .title(format!("Candidates ({})", decision.candidates.len()))
+                .style(popup_style()),
         )
+        .style(popup_style())
         .highlight_style(Style::default().bg(Color::Blue).fg(Color::White))
         .highlight_symbol(">> ");
     frame.render_stateful_widget(list, rows[1], &mut picker.list_state);
 
-    let help =
-        Paragraph::new("Enter pick  |  c clear selection  |  Esc cancel  |  j/k move").wrap(Wrap { trim: true });
+    let help = Paragraph::new("Enter pick  |  c clear selection  |  Esc cancel  |  j/k move")
+        .style(popup_style())
+        .wrap(Wrap { trim: true });
     frame.render_widget(help, rows[2]);
 }
 
@@ -5744,7 +5744,20 @@ fn run_app(
                     app.set_status("Decision picker cancelled");
                 }
                 KeyCode::Enter => {
-                    app.imports_state.confirm_decision_picker();
+                    let picked = app.imports_state.confirm_decision_picker();
+                    let unresolved = app.imports_state.unresolved_decisions();
+                    if let Some(account) = picked {
+                        let short_account = account.rsplit_once(':').map_or(account.as_str(), |(_, tail)| tail);
+                        if unresolved == 0 {
+                            app.set_status(format!(
+                                "Picked {short_account}. All decisions resolved — press `a` to apply."
+                            ));
+                        } else {
+                            app.set_status(format!(
+                                "Picked {short_account}. {unresolved} decision(s) still unresolved — press Enter again to pick the next one, or `a` to apply once done."
+                            ));
+                        }
+                    }
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
                     if let Some(picker) = app.imports_state.decision_picker.as_mut() {

--- a/tests/test_chequing_decisions.py
+++ b/tests/test_chequing_decisions.py
@@ -1,0 +1,281 @@
+"""Tests for ambiguous-account decisions surfaced via preflight + override-driven apply."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+from decimal import Decimal
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
+from beanbeaver.application.imports import account_discovery, chequing
+
+
+def _install_open_accounts(
+    monkeypatch: MonkeyPatch,
+    *,
+    cc_accounts: list[str],
+    chequing_accounts: list[str] | None = None,
+    bank_transfer_accounts: list[str] | None = None,
+) -> None:
+    if bank_transfer_accounts is None:
+        bank_transfer_accounts = []
+    if chequing_accounts is None:
+        chequing_accounts = ["Assets:Bank:Chequing:EQBankJoint0914"]
+
+    def fake_find_open_accounts(patterns: list[str], **_kwargs: object) -> list[str]:
+        joined = " ".join(patterns)
+        if "Liabilities:CreditCard" in joined:
+            return cc_accounts
+        if "Assets:Bank:Chequing" in joined:
+            return chequing_accounts
+        if "Assets:Bank" in joined:
+            return bank_transfer_accounts
+        return []
+
+    monkeypatch.setattr(account_discovery, "find_open_accounts", fake_find_open_accounts)
+    monkeypatch.setattr(chequing, "find_open_accounts", fake_find_open_accounts)
+
+
+def test_strict_cc_resolver_returns_ambiguous_data(monkeypatch: MonkeyPatch) -> None:
+    _install_open_accounts(
+        monkeypatch,
+        cc_accounts=[
+            "Liabilities:CreditCard:Amex:Gold",
+            "Liabilities:CreditCard:Amex:Plat",
+        ],
+    )
+    resolution = account_discovery.resolve_cc_payment_account_strict(
+        "AMEX BILL PYMT 04APR",
+    )
+    assert resolution.kind == "ambiguous"
+    assert resolution.pattern == "AMEX BILL PYMT"
+    assert resolution.candidates == (
+        "Liabilities:CreditCard:Amex:Gold",
+        "Liabilities:CreditCard:Amex:Plat",
+    )
+
+
+def test_strict_cc_resolver_returns_resolved_when_unique(monkeypatch: MonkeyPatch) -> None:
+    _install_open_accounts(monkeypatch, cc_accounts=["Liabilities:CreditCard:Amex:Plat"])
+    resolution = account_discovery.resolve_cc_payment_account_strict("AMEX BILL PYMT")
+    assert resolution.kind == "resolved"
+    assert resolution.account == "Liabilities:CreditCard:Amex:Plat"
+
+
+def test_strict_cc_resolver_returns_no_match_when_pattern_missing(monkeypatch: MonkeyPatch) -> None:
+    _install_open_accounts(monkeypatch, cc_accounts=[])
+    resolution = account_discovery.resolve_cc_payment_account_strict("Coffee Shop")
+    assert resolution.kind == "no_match"
+
+
+def test_legacy_cc_wrapper_raises_when_ambiguous_non_tty(monkeypatch: MonkeyPatch) -> None:
+    _install_open_accounts(
+        monkeypatch,
+        cc_accounts=[
+            "Liabilities:CreditCard:Amex:Gold",
+            "Liabilities:CreditCard:Amex:Plat",
+        ],
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    try:
+        account_discovery.resolve_cc_payment_account(
+            "AMEX BILL PYMT",
+            txn_date=dt.date(2026, 4, 6),
+            amount="-883.35 CAD",
+        )
+    except RuntimeError as exc:
+        assert "AMEX BILL PYMT" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError on ambiguous CC resolution without TTY")
+
+
+def _write_eqbank_csv(path: Path, rows: list[tuple[str, str, str, str]]) -> None:
+    """Write a minimal EQ Bank-format CSV with given (date, description, amount, balance) tuples."""
+    header = "Transfer date,Description,Amount,Balance\n"
+    body = "\n".join(",".join(cell for cell in row) for row in rows)
+    path.write_text(header + body + "\n", encoding="utf-8")
+
+
+def test_preflight_emits_per_row_decisions_for_repeated_pattern(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    csv_path = tmp_path / "Eqbank.csv"
+    _write_eqbank_csv(
+        csv_path,
+        rows=[
+            ("2026-04-06", "AMEX BILL PYMT 04APR", "-883.35", "1000.00"),
+            ("2026-04-08", "AMEX BILL PYMT 08APR", "-150.00", "850.00"),
+        ],
+    )
+
+    _install_open_accounts(
+        monkeypatch,
+        cc_accounts=[
+            "Liabilities:CreditCard:Amex:Gold",
+            "Liabilities:CreditCard:Amex:Plat",
+        ],
+        chequing_accounts=["Assets:Bank:Chequing:EQBankJoint0914"],
+    )
+
+    result = chequing.preflight_chequing_import(csv_file=str(csv_path))
+    assert result.status == "ok"
+    assert result.chequing_type == "eqbank"
+    assert result.account == "Assets:Bank:Chequing:EQBankJoint0914"
+    assert len(result.decisions) == 2
+
+    by_amount = {decision.transaction.amount: decision for decision in result.decisions}
+    assert set(by_amount) == {"-883.35", "-150.00"}
+    for decision in result.decisions:
+        assert decision.kind == "cc_payment"
+        assert decision.pattern == "AMEX BILL PYMT"
+        assert set(decision.candidates) == {
+            "Liabilities:CreditCard:Amex:Gold",
+            "Liabilities:CreditCard:Amex:Plat",
+        }
+
+
+def test_preflight_returns_error_when_csv_missing(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    result = chequing.preflight_chequing_import(csv_file=str(tmp_path / "missing.csv"))
+    assert result.status == "error"
+    assert result.error is not None
+
+
+def test_preflight_returns_error_when_chequing_account_unknown(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    csv_path = tmp_path / "Eqbank.csv"
+    _write_eqbank_csv(
+        csv_path,
+        rows=[("2026-04-06", "PAYROLL", "1000.00", "1000.00")],
+    )
+    _install_open_accounts(
+        monkeypatch,
+        cc_accounts=[],
+        chequing_accounts=[],
+    )
+    result = chequing.preflight_chequing_import(csv_file=str(csv_path))
+    assert result.status == "error"
+    assert result.error is not None
+
+
+def test_apply_with_overrides_skips_prompts_per_row(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    csv_path = tmp_path / "Eqbank.csv"
+    _write_eqbank_csv(
+        csv_path,
+        rows=[
+            ("2026-04-06", "AMEX BILL PYMT 04APR", "-883.35", "1000.00"),
+            ("2026-04-08", "AMEX BILL PYMT 08APR", "-150.00", "850.00"),
+        ],
+    )
+
+    _install_open_accounts(
+        monkeypatch,
+        cc_accounts=[
+            "Liabilities:CreditCard:Amex:Gold",
+            "Liabilities:CreditCard:Amex:Plat",
+        ],
+        chequing_accounts=["Assets:Bank:Chequing:EQBankJoint0914"],
+    )
+    monkeypatch.setattr(chequing, "confirm_uncommitted_changes", lambda *_a, **_k: True)
+    monkeypatch.setattr(chequing, "get_existing_transaction_dates", lambda _account: set())
+    monkeypatch.setattr(chequing, "validate_ledger", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        chequing,
+        "load_chequing_categorization_patterns",
+        lambda: (("__NO_MATCH__", "Expenses:Uncategorized"),),
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_write(*, output_content: str, result_file_name: str, **_kwargs: object) -> Path:
+        captured["output"] = output_content
+        captured["name"] = result_file_name
+        return tmp_path / result_file_name
+
+    monkeypatch.setattr(chequing, "write_import_output", fake_write)
+
+    overrides = (
+        chequing.TransactionOverride(
+            transaction=account_discovery.TransactionKey(
+                date="2026-04-06",
+                description="AMEX BILL PYMT 04APR",
+                amount="-883.35",
+            ),
+            account="Liabilities:CreditCard:Amex:Gold",
+        ),
+        chequing.TransactionOverride(
+            transaction=account_discovery.TransactionKey(
+                date="2026-04-08",
+                description="AMEX BILL PYMT 08APR",
+                amount="-150.00",
+            ),
+            account="Liabilities:CreditCard:Amex:Plat",
+        ),
+    )
+
+    result = chequing.run_chequing_import(
+        chequing.ChequingImportRequest(
+            csv_file=str(csv_path),
+            allow_uncommitted=True,
+            cc_payment_overrides=overrides,
+            interactive=False,
+        ),
+        emit_console_output=False,
+    )
+    assert result.status == "ok", result.error
+    output = captured["output"]
+    assert isinstance(output, str)
+    assert "Liabilities:CreditCard:Amex:Gold" in output
+    assert "Liabilities:CreditCard:Amex:Plat" in output
+
+
+def test_apply_without_overrides_returns_clean_error_for_ambiguous(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    csv_path = tmp_path / "Eqbank.csv"
+    _write_eqbank_csv(
+        csv_path,
+        rows=[
+            ("2026-04-06", "AMEX BILL PYMT 04APR", "-883.35", "1000.00"),
+        ],
+    )
+    _install_open_accounts(
+        monkeypatch,
+        cc_accounts=[
+            "Liabilities:CreditCard:Amex:Gold",
+            "Liabilities:CreditCard:Amex:Plat",
+        ],
+    )
+    monkeypatch.setattr(chequing, "confirm_uncommitted_changes", lambda *_a, **_k: True)
+    monkeypatch.setattr(chequing, "get_existing_transaction_dates", lambda _account: set())
+    monkeypatch.setattr(
+        chequing,
+        "load_chequing_categorization_patterns",
+        lambda: (("__NO_MATCH__", "Expenses:Uncategorized"),),
+    )
+
+    result = chequing.run_chequing_import(
+        chequing.ChequingImportRequest(
+            csv_file=str(csv_path),
+            allow_uncommitted=True,
+            interactive=False,
+        ),
+        emit_console_output=False,
+    )
+    assert result.status == "error"
+    assert result.error is not None
+    assert "ambiguous" in result.error.lower()
+
+
+def test_decimal_smoke_module_import() -> None:
+    """Sanity import: the module is fresh-loadable with no circular issues."""
+    importlib.reload(chequing)
+    assert hasattr(chequing, "preflight_chequing_import")
+    assert isinstance(Decimal("1.00"), Decimal)


### PR DESCRIPTION
Chequing imports that hit multiple matching credit-card or bank-transfer accounts (e.g. two open AMEX cards for an "AMEX BILL PYMT" row) used to prompt mid-import; the TUI has no stdin, so the whole import aborted. Add a preflight pass that surfaces every ambiguous row as a per- transaction decision the user picks in a new Decisions pane before applying. Apply is gated until all decisions are resolved, and the selections flow through to the import as transaction-keyed overrides.