### PR TITLE
fix(rules): classify soy-sauce chicken and puffed snacks correctly

### DIFF
--- a/rules/default_item_classifier.toml
+++ b/rules/default_item_classifier.toml
@@ -112,7 +112,7 @@ exact_only = false
 
 [[rules]]
 id = "legacy_0013"
-keywords = ["ROTISSERIE CHICKEN", "PREPARED MEAL", "DELI MEAL", "READY TO EAT", "HEAT AND SERVE", "MEAL KIT"]
+keywords = ["ROTISSERIE CHICKEN", "SOY SAUCE CHICKEN", "PREPARED MEAL", "DELI MEAL", "READY TO EAT", "HEAT AND SERVE", "MEAL KIT"]
 category = "grocery_prepared_meal"
 tags = ["grocery", "prepared", "meal"]
 priority = 0
@@ -160,7 +160,7 @@ exact_only = false
 
 [[rules]]
 id = "legacy_0021"
-keywords = ["POTATO CHIPS", "CHIP", "CHIPS", "POPCORN", "PRETZEL", "NUTS", "ALMONDS", "CASHEWS", "PEANUTS", "WALNUTS", "PISTACHIOS", "TRAIL MIX", "GRANOLA BAR", "PROTEIN BAR", "ENERGY BAR", "CANDY", "CHOCOLATE", "GUMMY", "GUMMIES", "SKITTLES", "M&M", "SNICKERS", "TWIX", "KITKAT", "REESE", "OREO", "GOLDFISH", "CHEETOS", "DORITOS", "PRINGLES", "LAYS", "RUFFLES", "TOSTITOS", "CHEEZ-IT", "RITZ"]
+keywords = ["POTATO CHIPS", "POTATO PUFFED", "PUFFED FOOD", "CHIP", "CHIPS", "POPCORN", "PRETZEL", "NUTS", "ALMONDS", "CASHEWS", "PEANUTS", "WALNUTS", "PISTACHIOS", "TRAIL MIX", "GRANOLA BAR", "PROTEIN BAR", "ENERGY BAR", "CANDY", "CHOCOLATE", "GUMMY", "GUMMIES", "SKITTLES", "M&M", "SNICKERS", "TWIX", "KITKAT", "REESE", "OREO", "GOLDFISH", "CHEETOS", "DORITOS", "PRINGLES", "LAYS", "RUFFLES", "TOSTITOS", "CHEEZ-IT", "RITZ"]
 category = "grocery_snacks"
 tags = ["grocery", "snacks"]
 priority = 0


### PR DESCRIPTION
## What

Fix two item-classifier misfires in `rules/default_item_classifier.toml`:

- `SOY SAUCE CHICKEN LEG` → was **Seasoning**, now **PreparedMeal**
- `POTATO PUFFED FOOD …` → was **Vegetable**, now **Snacks**

## Why

`find_all_matches` breaks ties by **priority → exact-match → keyword length → rule order**. Both items matched a shorter/adjacent keyword that won the tiebreak:

- `"SOY SAUCE"` (len 9) beat meat's `"CHICKEN"` (len 7) → Seasoning
- only `"POTATO"` matched (no snack keyword) → Vegetable

## Fix

Add longer, exact keywords so the correct rule wins deterministically:

- prepared_meal: `+ "SOY SAUCE CHICKEN"`
- snacks: `+ "POTATO PUFFED", "PUFFED FOOD"`

## Verification

- Both items now classify correctly from **public rules alone** (no overrides).
- Full **90-case cached E2E corpus** (`beanbeaver-private-test`): **0 regressions**.

## Provenance / follow-ups

- Surfaced by the private E2E corpus; both were previously masked by `category_optional` / real-ledger private overrides, now removed there.
- `rules/default_item_classifier.toml` is byte-identical in **beanbeaver-core** — mirror this change there when the rule sets are unified.
- Follow-up in `beanbeaver-private-test`: prune the now-redundant `SOY SAUCE CHICKEN LEG` override and the `POTATO PUFFED FOOD SEAWEE` keyword once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
