### PR TITLE
Desktop parity for portable receipt identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "ocr-paddle"
 version = "0.1.0"
-source = "git+https://github.com/Endle/beanbeaver-core?tag=v0.1.0#108ad4b8fae6eda1703ebb33c1225e5422b80b48"
+source = "git+https://github.com/Endle/beanbeaver-core?tag=v0.2.0#f6ea0f22eef8a15c7b65766c5a19f64640c2e3d1"
 dependencies = [
  "geo",
  "image",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "receipt-core"
 version = "0.1.0"
-source = "git+https://github.com/Endle/beanbeaver-core?tag=v0.1.0#108ad4b8fae6eda1703ebb33c1225e5422b80b48"
+source = "git+https://github.com/Endle/beanbeaver-core?tag=v0.2.0#f6ea0f22eef8a15c7b65766c5a19f64640c2e3d1"
 dependencies = [
  "regex",
  "serde",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "receipt-image"
 version = "0.1.0"
-source = "git+https://github.com/Endle/beanbeaver-core?tag=v0.1.0#108ad4b8fae6eda1703ebb33c1225e5422b80b48"
+source = "git+https://github.com/Endle/beanbeaver-core?tag=v0.2.0#f6ea0f22eef8a15c7b65766c5a19f64640c2e3d1"
 dependencies = [
  "image",
 ]
@@ -1852,7 +1852,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2142,7 +2142,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,14 @@ native-ocr = ["dep:ocr-paddle", "dep:image"]
 # the `tag =` below — editing this repo's rules/*.toml alone will NOT affect the
 # Rust side.
 [dependencies]
-receipt-core = { git = "https://github.com/Endle/beanbeaver-core", tag = "v0.1.0" }
-receipt-image = { git = "https://github.com/Endle/beanbeaver-core", tag = "v0.1.0" }
-ocr-paddle = { git = "https://github.com/Endle/beanbeaver-core", tag = "v0.1.0", optional = true }
+# DEV: tracking the beanbeaver-core dev branch for the portable-receipt-identity
+# work (format_enriched_transaction gained beanbeaver_id/document args; scanned
+# receipts now emit real `beanbeaver-id`/`document:` metadata). Re-pin to a cut
+# tag (e.g. v0.2.0) before merging to master, and run `cargo update -p
+# receipt-core` once the branch is pushed to refresh Cargo.lock.
+receipt-core = { git = "https://github.com/Endle/beanbeaver-core", branch = "dev/portable-receipt-identity" }
+receipt-image = { git = "https://github.com/Endle/beanbeaver-core", branch = "dev/portable-receipt-identity" }
+ocr-paddle = { git = "https://github.com/Endle/beanbeaver-core", branch = "dev/portable-receipt-identity", optional = true }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true }
 crossterm = "0.28"
 pyo3 = { version = "0.28", features = ["extension-module"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,9 @@ native-ocr = ["dep:ocr-paddle", "dep:image"]
 # the `tag =` below — editing this repo's rules/*.toml alone will NOT affect the
 # Rust side.
 [dependencies]
-# DEV: tracking the beanbeaver-core dev branch for the portable-receipt-identity
-# work (format_enriched_transaction gained beanbeaver_id/document args; scanned
-# receipts now emit real `beanbeaver-id`/`document:` metadata). Re-pin to a cut
-# tag (e.g. v0.2.0) before merging to master, and run `cargo update -p
-# receipt-core` once the branch is pushed to refresh Cargo.lock.
-receipt-core = { git = "https://github.com/Endle/beanbeaver-core", branch = "dev/portable-receipt-identity" }
-receipt-image = { git = "https://github.com/Endle/beanbeaver-core", branch = "dev/portable-receipt-identity" }
-ocr-paddle = { git = "https://github.com/Endle/beanbeaver-core", branch = "dev/portable-receipt-identity", optional = true }
+receipt-core = { git = "https://github.com/Endle/beanbeaver-core", tag = "v0.2.0" }
+receipt-image = { git = "https://github.com/Endle/beanbeaver-core", tag = "v0.2.0" }
+ocr-paddle = { git = "https://github.com/Endle/beanbeaver-core", tag = "v0.2.0", optional = true }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"], optional = true }
 crossterm = "0.28"
 pyo3 = { version = "0.28", features = ["extension-module"] }

--- a/src/match_service.rs
+++ b/src/match_service.rs
@@ -761,10 +761,15 @@ pub(crate) fn apply_receipt_match_service(
     }
 
     let receipt_name = receipt_chain_name(approved_receipt_path)?;
+    // beanbeaver_id/document carry-forward is the Phase 5 pairing matcher's job
+    // (it reads them off the receipt's ledger entry); this staged-JSON apply path
+    // predates that, so it emits no identity metadata on the merged transaction.
     let enriched = format_enriched_transaction(
         &formatter_receipt_input(&receipt),
         &formatter_match_input(&candidate, selected_transaction),
         "Expenses:FIXME",
+        None,
+        None,
     );
     let enriched_dir = matched_file
         .parent()

--- a/src/python_receipt_formatter.rs
+++ b/src/python_receipt_formatter.rs
@@ -182,10 +182,16 @@ fn receipt_format_enriched_transaction(
 ) -> PyResult<String> {
     let input = extract_formatter_receipt_input(receipt, item_accounts)?;
     let match_input = extract_enriched_match_input(match_obj)?;
+    // Identity carry-forward onto matched entries is handled by the Phase 5
+    // pairing matcher, which reads `beanbeaver-id`/`document:` off the receipt's
+    // existing ledger entry. This legacy staged-JSON apply path has no ledger
+    // entry (nor a sha on the domain Receipt), so it emits none here.
     Ok(receipt_formatter::format_enriched_transaction(
         &input,
         &match_input,
         &default_expense,
+        None,
+        None,
     ))
 }
 

--- a/src/python_receipt_parse_helpers.rs
+++ b/src/python_receipt_parse_helpers.rs
@@ -71,12 +71,18 @@ fn receipt_extract_merchant(
     pages: Vec<PyMerchantPageInput>,
     known_merchants: Option<Vec<String>>,
 ) -> String {
-    receipt_parse_helpers::extract_merchant(
+    // Core replaced extract_merchant (raw string) with fuzzy extract_merchant_match;
+    // `.display()` keeps the old contract — canonical name only on a trusted
+    // (exact/corrected) match, else the raw OCR header.
+    receipt_parse_helpers::extract_merchant_match(
         &lines,
         full_text,
         &pages.into_iter().map(to_page_input).collect::<Vec<_>>(),
         &known_merchants.unwrap_or_default(),
+        &receipt_core::rules::default_merchant_families(),
     )
+    .display()
+    .to_string()
 }
 
 #[pyfunction]

--- a/src/python_receipt_parser.rs
+++ b/src/python_receipt_parser.rs
@@ -332,6 +332,10 @@ fn receipt_parse_receipt(
         None => Vec::new(),
     };
 
+    // Rust-side merchant families come from beanbeaver-core's bundled rules
+    // (the native-OCR path deliberately uses core's rules, per Cargo.toml), same
+    // as core's own process_receipt.
+    let merchant_families = receipt_core::rules::default_merchant_families();
     let parsed = receipt_parser::parse_receipt(
         &full_text,
         &to_helper_pages(pages.clone()),
@@ -339,6 +343,7 @@ fn receipt_parse_receipt(
         &to_rule_layers(rule_layers),
         &image_filename,
         &known_merchants.unwrap_or_default(),
+        &merchant_families,
         current_year,
     );
 
@@ -377,6 +382,7 @@ fn receipt_parse_receipt_from_raw(
     };
 
     let transformed = ocr_transform::transform(detections, padded_width, padded_height, padding);
+    let merchant_families = receipt_core::rules::default_merchant_families();
     let parsed = receipt_parser::parse_receipt(
         &transformed.full_text,
         &transformed.helper_pages,
@@ -384,6 +390,7 @@ fn receipt_parse_receipt_from_raw(
         &to_rule_layers(rule_layers),
         &image_filename,
         &known_merchants.unwrap_or_default(),
+        &merchant_families,
         current_year,
     );
 

--- a/tests/test_receipt_formatter.py
+++ b/tests/test_receipt_formatter.py
@@ -39,7 +39,11 @@ def test_format_parsed_receipt_renders_expected_metadata_and_warning_anchor() ->
     output = format_parsed_receipt(receipt, image_sha256="abc123")
 
     assert '; @merchant: Fresh "Mart"' in output
-    assert "; @image_sha256: abc123" in output
+    # Portable receipt identity: real beancount metadata (greppable), not a
+    # `; @image*` comment. Content-hash token shared by id + document filename.
+    assert '  beanbeaver-id: "bb-20260305-abc123"' in output
+    assert '  beanbeaver-image-sha256: "abc123"' in output
+    assert '  document: "beanbeaver/2026-03-05-fresh-mart-abc123.jpg"' in output
     assert '2026-03-05 * "Fresh \'Mart\'" "Receipt scan"' in output
     assert "Liabilities:CreditCard:PENDING" in output
     assert "card ****1234" in output


### PR DESCRIPTION
## What & why

Track the beanbeaver-core change (Endle/beanbeaver-core#5) that adds portable receipt-identity metadata. Desktop-scanned/parsed receipts now emit real `beanbeaver-id`, `beanbeaver-image-sha256`, and native `document:` metadata (greppable, resolves across arbitrary user layouts) instead of `; @image*` comments.

Parsed-receipt parity flows through **automatically**: `format_parsed_receipt` is the same core fn, and `stage_renderer` already supplies the image sha. No behavior change needed beyond the pin bump + test.

## Changes

- **Cargo.toml**: pin `receipt-core`/`receipt-image`/`ocr-paddle` to the core dev branch. Re-pin to a cut tag (e.g. `v0.2.0`) before merge; run `cargo update -p receipt-core` after the branch is pushed.
- **`python_receipt_formatter.rs` / `match_service.rs`**: pass the new `beanbeaver_id`/`document` args to `format_enriched_transaction` (`None` here). Carry-forward onto **matched** entries is the Phase 5 pairing matcher's job — it reads the id off the receipt's existing ledger entry. The legacy staged-JSON apply paths have no ledger entry (nor a sha on the domain `Receipt`), so they emit none.
- **`test_receipt_formatter.py`**: assert the new metadata block.

## Verification ⚠️

**Not compile/test-verified locally** — the core dep is an unpushed→now-pushed dev branch and the PyO3 build needs pixi/maturin. Verify after re-pinning to a core tag: `cargo update -p receipt-core` then the pixi test suite.

## Depends on

Endle/beanbeaver-core#5 (merge + tag first, then re-pin here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsKC91wFj3EYcHXSxLMusm