### PR TITLE
refactor: hoist duplicated PyRuleEntry into python_receipt_common

### DIFF
--- a/src/python_receipt_categories.rs
+++ b/src/python_receipt_categories.rs
@@ -6,26 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 use receipt_core::receipt_categories;
 
-#[derive(Clone, Debug)]
-struct PyRuleEntry {
-    keywords: Vec<String>,
-    category: Option<String>,
-    tags: Vec<String>,
-    priority: i32,
-}
-
-impl<'a, 'py> FromPyObject<'a, 'py> for PyRuleEntry {
-    type Error = PyErr;
-
-    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        Ok(Self {
-            keywords: ob.getattr("keywords")?.extract::<Vec<String>>()?,
-            category: ob.getattr("category")?.extract::<Option<String>>()?,
-            tags: ob.getattr("tags")?.extract::<Vec<String>>()?,
-            priority: ob.getattr("priority")?.extract::<i32>()?,
-        })
-    }
-}
+use crate::python_receipt_common::PyRuleEntry;
 
 #[derive(Clone, Debug)]
 struct PyBuildRuleEntry {
@@ -186,12 +167,7 @@ fn to_rule_layers(input: PyRuleLayersInput) -> receipt_categories::CategoryRuleL
         rules: input
             .rules
             .into_iter()
-            .map(|rule| receipt_categories::CategoryRule {
-                keywords: rule.keywords,
-                category: rule.category,
-                tags: rule.tags,
-                priority: rule.priority,
-            })
+            .map(receipt_categories::CategoryRule::from)
             .collect(),
         exact_only_keywords: input.exact_only_keywords,
         account_mapping: input.account_mapping,

--- a/src/python_receipt_common.rs
+++ b/src/python_receipt_common.rs
@@ -3,7 +3,43 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::wrap_pyfunction;
 
+use receipt_core::receipt_categories;
 use receipt_core::receipt_common;
+
+/// Python-side item-category rule entry, mirrored across the receipt wrappers
+/// (parser / categories / staged-json). Extracted from a Python object exposing
+/// `keywords` / `category` / `tags` / `priority`.
+#[derive(Clone, Debug)]
+pub(crate) struct PyRuleEntry {
+    keywords: Vec<String>,
+    category: Option<String>,
+    tags: Vec<String>,
+    priority: i32,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for PyRuleEntry {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            keywords: ob.getattr("keywords")?.extract::<Vec<String>>()?,
+            category: ob.getattr("category")?.extract::<Option<String>>()?,
+            tags: ob.getattr("tags")?.extract::<Vec<String>>()?,
+            priority: ob.getattr("priority")?.extract::<i32>()?,
+        })
+    }
+}
+
+impl From<PyRuleEntry> for receipt_categories::CategoryRule {
+    fn from(rule: PyRuleEntry) -> Self {
+        receipt_categories::CategoryRule {
+            keywords: rule.keywords,
+            category: rule.category,
+            tags: rule.tags,
+            priority: rule.priority,
+        }
+    }
+}
 
 fn decimalish_to_string(value: &Bound<'_, PyAny>) -> PyResult<Option<String>> {
     if value.is_none() {

--- a/src/python_receipt_parser.rs
+++ b/src/python_receipt_parser.rs
@@ -10,26 +10,7 @@ use receipt_core::receipt_parse_helpers;
 use receipt_core::receipt_parser;
 use receipt_core::receipt_spatial;
 
-#[derive(Clone, Debug)]
-struct PyRuleEntry {
-    keywords: Vec<String>,
-    category: Option<String>,
-    tags: Vec<String>,
-    priority: i32,
-}
-
-impl<'a, 'py> FromPyObject<'a, 'py> for PyRuleEntry {
-    type Error = PyErr;
-
-    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        Ok(Self {
-            keywords: ob.getattr("keywords")?.extract::<Vec<String>>()?,
-            category: ob.getattr("category")?.extract::<Option<String>>()?,
-            tags: ob.getattr("tags")?.extract::<Vec<String>>()?,
-            priority: ob.getattr("priority")?.extract::<i32>()?,
-        })
-    }
-}
+use crate::python_receipt_common::PyRuleEntry;
 
 #[derive(Clone, Debug)]
 struct PyRuleLayersInput {
@@ -73,12 +54,7 @@ fn to_rule_layers(input: PyRuleLayersInput) -> receipt_parser::ParserRuleLayers 
             rules: input
                 .rules
                 .into_iter()
-                .map(|rule| receipt_categories::CategoryRule {
-                    keywords: rule.keywords,
-                    category: rule.category,
-                    tags: rule.tags,
-                    priority: rule.priority,
-                })
+                .map(receipt_categories::CategoryRule::from)
                 .collect(),
             exact_only_keywords: input.exact_only_keywords,
             account_mapping: category_account_mapping,

--- a/src/python_receipt_staged_json.rs
+++ b/src/python_receipt_staged_json.rs
@@ -7,26 +7,7 @@ use std::collections::HashSet;
 use receipt_core::receipt_categories;
 use receipt_core::receipt_staged_json;
 
-#[derive(Clone, Debug)]
-struct PyRuleEntry {
-    keywords: Vec<String>,
-    category: Option<String>,
-    tags: Vec<String>,
-    priority: i32,
-}
-
-impl<'a, 'py> FromPyObject<'a, 'py> for PyRuleEntry {
-    type Error = PyErr;
-
-    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        Ok(Self {
-            keywords: ob.getattr("keywords")?.extract::<Vec<String>>()?,
-            category: ob.getattr("category")?.extract::<Option<String>>()?,
-            tags: ob.getattr("tags")?.extract::<Vec<String>>()?,
-            priority: ob.getattr("priority")?.extract::<i32>()?,
-        })
-    }
-}
+use crate::python_receipt_common::PyRuleEntry;
 
 #[derive(Clone, Debug)]
 struct PyStageRuleLayersInput {
@@ -72,12 +53,7 @@ fn to_stage_rule_layers(input: PyStageRuleLayersInput) -> receipt_staged_json::S
             rules: input
                 .rules
                 .into_iter()
-                .map(|rule| receipt_categories::CategoryRule {
-                    keywords: rule.keywords,
-                    category: rule.category,
-                    tags: rule.tags,
-                    priority: rule.priority,
-                })
+                .map(receipt_categories::CategoryRule::from)
                 .collect(),
             exact_only_keywords: input.exact_only_keywords,
             account_mapping: category_account_mapping,


### PR DESCRIPTION
Axis 2 of the desktop duplicate-code cleanup: collapse the byte-identical PyO3 mirror struct that was copy-pasted across three wrapper modules.

### What was duplicated
`PyRuleEntry` (the Python-side item-category rule mirror — `keywords`/`category`/`tags`/`priority`) plus its `FromPyObject` impl appeared **identically** in:
- `src/python_receipt_parser.rs`
- `src/python_receipt_categories.rs`
- `src/python_receipt_staged_json.rs`

…and each module then repeated the same `PyRuleEntry → receipt_categories::CategoryRule` field-by-field map.

### Change
- Define `PyRuleEntry` once in `src/python_receipt_common.rs`.
- Add `impl From<PyRuleEntry> for receipt_categories::CategoryRule`, so the three conversions collapse to `.map(receipt_categories::CategoryRule::from)`.
- Net **−36 lines**; no behavior change.

### Deliberately NOT merged (verified they are *not* true duplicates)
- **`PyRuleLayersInput`** — same name, different types: parser uses `Vec<(String,String)>` → `ParserRuleLayers`; categories uses `HashMap` → `CategoryRuleLayers` with extra emptiness validation.
- **`PyBboxInput`** — identical shape, but parser's `FromPyObject` is *lenient* (missing fields → `0.0`) while spatial's is *strict* (missing → error). Merging would silently change behavior.

### Verification
- `cargo check --all-targets` ✅
- `tests/test_item_categories.py` + `tests/test_receipt_core_parity.py`: **66 passed** ✅

Independent of the v0.3.2 bump (#125) — based on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)